### PR TITLE
109 feat project management service provider

### DIFF
--- a/lib/controller/anomaly_detector_controller.dart
+++ b/lib/controller/anomaly_detector_controller.dart
@@ -11,12 +11,11 @@ class AnomalyDetectorController {
   /// Gets the project information from the anomaly detection service.
   ///
   /// Currently does not use information for anything, but response has been tested with print so it is ready for implementation.
-  Future<void> getProjectInfo({
+  Future<DescribeAnomalyProjectResponse> getProjectInfo({
     required String projectName,
     required String imagePath,
     required String sosiPath,
-  }) async {
-    await anomalyDetectorClient.describeAnomalyProject(
+  }) async => await anomalyDetectorClient.describeAnomalyProject(
       DescribeAnomalyProjectRequest(
         projectMetadata: ProjectMetadata(
           sosiFilePath: sosiPath,
@@ -25,12 +24,11 @@ class AnomalyDetectorController {
         ),
       ),
     );
-  }
 
   /// Sends a start procedure to the anomaly service with supplied data.
   ///
   /// Currently does not use information for anything, but response has been tested with print so it is ready for implementation.
-  Future<void> runAnalysis({
+  Future<DetectAnomalySetResponse> runAnalysis({
     required String imagePath,
     required String sosiPath,
     required String projectName,
@@ -45,7 +43,7 @@ class AnomalyDetectorController {
       metadata.sosiWaterMaskPath = waterSosiPath;
     }
 
-    await anomalyDetectorClient.detectAnomalySet(
+    return await anomalyDetectorClient.detectAnomalySet(
       DetectAnomalySetRequest(
         projectMetadata: metadata,
         startMode: StartMode.START_RESTART,

--- a/lib/entity/anomaly_set.dart
+++ b/lib/entity/anomaly_set.dart
@@ -1,10 +1,11 @@
+import 'package:skavl/entity/anomaly_def.dart';
 
 /// Represents each "set" of data included in a page of the main application.
 /// Each detected anomaly will be a set and the data on this set will be used
 /// to display the image, surrounding images and the anomaly definition.
 class AnomalySet {
   final String imageName;
-  final Enum anomalyDef;
+  final AnomalyDef anomalyDef;
   final double anomalyConf;
   final int lineNumber;
   final int imageNumber;
@@ -16,4 +17,22 @@ class AnomalySet {
     required this.lineNumber,
     required this.imageNumber,
   });
+
+  /// For project management
+  Map<String, dynamic> toJson() => {
+    'imageName': imageName,
+    'anomalyConf': anomalyConf,
+    'lineNumber': lineNumber,
+    'imageNumber': imageNumber,
+    'anomalyDef': anomalyDef.name,
+  };
+
+  /// For project management
+  factory AnomalySet.fromJson(Map<String, dynamic> json) => AnomalySet(
+    imageName: json['imageName'] as String,
+    anomalyConf: (json['anomalyConf'] as num).toDouble(),
+    lineNumber: json['lineNumber'] as int,
+    imageNumber: json['imageNumber'] as int,
+    anomalyDef: AnomalyDef.values.byName(json['anomalyDef'] as String),
+  );
 }

--- a/lib/entity/project_metadata.dart
+++ b/lib/entity/project_metadata.dart
@@ -1,5 +1,3 @@
-
-
 import 'package:skavl/entity/anomaly_set.dart';
 
 /// Represents the metadata per project loaded. This class will probably be
@@ -12,16 +10,73 @@ import 'package:skavl/entity/anomaly_set.dart';
 /// currentPage is the current anomaly being analyzed within the range 1..Size(anomaliesInRange)
 class ProjectMetadata {
   final String projectName;
+  final String sosiFilePath;
+  final String imageFolderPath;
+  final String? sosiWaterMaskPath;
   final List<AnomalySet> allSets;
-  final List<AnomalySet> anomaliesInRange;
   final double sensitivity;
   final int currentPage;
 
   ProjectMetadata({
     required this.projectName,
-    required this.allSets,
-    required this.anomaliesInRange,
-    required this.sensitivity,
-    required this.currentPage,
+    required this.sosiFilePath,
+    required this.imageFolderPath,
+    this.sosiWaterMaskPath,
+    this.allSets = const [],
+    this.sensitivity = 0.5,
+    this.currentPage = 0,
   });
+
+  /// For project management
+  Map<String, dynamic> toJson() => {
+    'version': 1,
+    'projectName': projectName,
+    'paths': {
+      'sosiFilePath': sosiFilePath,
+      'imageFolderPath': imageFolderPath,
+      'sosiWaterMaskPath': sosiWaterMaskPath,
+    },
+    'sensitivity': sensitivity,
+    'currentPage': currentPage,
+    'anomalySets': allSets.map((s) => s.toJson()).toList(),
+  };
+
+  /// For project management
+  factory ProjectMetadata.fromJson(Map<String, dynamic> json) {
+    final paths = json['paths'] as Map<String, dynamic>;
+    return ProjectMetadata(
+      projectName: json['projectName'] as String,
+      sosiFilePath: paths['sosiFilePath'] as String,
+      imageFolderPath: paths['imageFolderPath'] as String,
+      sosiWaterMaskPath: paths['sosiWaterMaskPath'] as String?,
+      sensitivity: (json['sensitivity'] as num).toDouble(),
+      currentPage: json['currentPage'] as int,
+      allSets: (json['anomalySets'] as List)
+          .map((e) => AnomalySet.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  /// For mutable project files
+  ProjectMetadata copyWith({
+    String? projectName,
+    String? sosiFilePath,
+    String? imageFolderPath,
+    String? sosiWaterMaskPath,
+    List<AnomalySet>? allSets,
+    double? sensitivity,
+    int? currentPage,
+  }) => ProjectMetadata(
+    projectName: projectName ?? this.projectName,
+    sosiFilePath: sosiFilePath ?? this.sosiFilePath,
+    imageFolderPath: imageFolderPath ?? this.imageFolderPath,
+    sosiWaterMaskPath: sosiWaterMaskPath ?? this.sosiWaterMaskPath,
+    allSets: allSets ?? this.allSets,
+    sensitivity: sensitivity ?? this.sensitivity,
+    currentPage: currentPage ?? this.currentPage,
+  );
+
+  /// Returns list of anomalies based on confidence and sensitivity
+  List<AnomalySet> get anomaliesInRange =>
+      allSets.where((s) => s.anomalyConf >= sensitivity).toList();
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -72,6 +72,11 @@
     "description": "Project"
   },
 
+  "g_noImagesProcessed": "No images processed",
+  "@g_noImagesProcessed": {
+    "description": "No images processed - text when no images have been processed yet"
+  },
+
   "settings_title": "Settings",
   "@settings_title": {},
 
@@ -226,6 +231,31 @@
   "anomalyClassifBar_searchCreate": "Search or create anomaly type",
   "@anomalyClassifBar_searchCreate": {
     "description": "Search or create anomaly type - text input hint"
+  },
+
+  "projectOverview_projectName": "Project name",
+  "@projectOverview_projectName": {
+    "description": "Project name - label for project name in project overview"
+  },
+
+  "projectOverview_noWaterSosi": "No water polygon SOSI associated with project",
+  "@projectOverview_noWaterSosi": {
+    "description": "Sosi water polygon file is missing - text when no water sosi file is linked to project"
+  },
+
+  "projectOverview_imagesPresent": "Number of images in folder",
+  "@projectOverview_imagesPresent": {
+    "description": "Number of images present in folder"
+  },
+
+  "projectOverview_imagesProcessed": "Number of images analyzed",
+  "@projectOverview_imagesProcessed": {
+    "description": "Number of images processed"
+  },
+
+  "projectOverview_lastImageProcessed": "Latest image analyzed",
+  "@projectOverview_lastImageProcessed": {
+    "description": "Last image that has been processed"
   }
 
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -21,6 +21,11 @@
     "description": "Used as a menu item for file, but also as file in general"
   },
 
+  "g_browse": "Browse",
+  "@g_browse": {
+    "description": "Used for browsing, mainly for upload buttons"
+  },
+
   "g_settings": "Settings",
   "@g_settings": {
     "description": "Used as a menu item for settings, but also as settings in general"
@@ -143,19 +148,29 @@
     "description": "Title - input field"
   },
 
-  "createPage_uploadPlaneImages": "Upload plane images",
+  "createPage_uploadPlaneImages": "Aerial image folder",
   "@createPage_uploadPlaneImages": {
     "description": "Upload plane images - text"
   },
 
-  "createPage_uploadSOSIFile": "Upload SOSI file",
+  "createPage_uploadSOSIFile": "Coverage SOSI",
   "@createPage_uploadSOSIFile": {
     "description": "Upload SOSI file - text"
   },
 
-  "createPage_uploadWaterSOSIFile": "Upload SOSI water polygon file",
+  "createPage_uploadWaterSOSIFile": "Water polygon SOSI",
   "@createPage_uploadWaterSOSIFile": {
     "description": "Last opp SOSI vannpolygon fil - text"
+  },
+
+  "createPage_noFile": "No file selected",
+  "@createPage_noFile": {
+    "description": "Ingen fil valgt - text when no file is chosen"
+  },
+
+  "createPage_noFolder": "No folder selected",
+  "@createPage_noFolder": {
+    "description": "Ingen mappe valgt - text when no folder is chosen"
   },
 
   "createPage_createReportButton": "Create report",
@@ -166,6 +181,21 @@
   "newprojectPage_title": "Create new project",
   "@newprojectPage_title": {
     "description": "Create new project - title"
+  },
+
+  "newprojectPage_Missingproject": "Missing project name",
+  "@newprojectPage_Missingproject": {
+    "description": "Missing project name from form"
+  },
+
+  "newprojectPage_Missingaerial": "Missing aerial image folder",
+  "@newprojectPage_Missingaerial": {
+    "description": "Missing aerial images from form"
+  },
+
+  "newprojectPage_Missingsosi": "Mangler coverage polygon SOSI",
+  "@newprojectPage_Missingsosi": {
+    "description": "Missing polygon SOSI from form"
   },
 
   "loadingDialog_analyzing": "Analyzing your aereal images",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -16,6 +16,11 @@
     "description": "Share something"
   },
 
+  "g_close": "Close",
+  "@g_close": {
+    "description": "Close something"
+  },
+
   "g_file": "File",
   "@g_file": {
     "description": "Used as a menu item for file, but also as file in general"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -62,6 +62,11 @@
     "description": "Confirm"
   },
 
+  "g_project": "Project",
+  "@g_project": {
+    "description": "Project"
+  },
+
   "settings_title": "Settings",
   "@settings_title": {},
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -153,9 +153,19 @@
     "description": "Upload SOSI file - text"
   },
 
+  "createPage_uploadWaterSOSIFile": "Upload SOSI water polygon file",
+  "@createPage_uploadWaterSOSIFile": {
+    "description": "Last opp SOSI vannpolygon fil - text"
+  },
+
   "createPage_createReportButton": "Create report",
   "@createPage_createReportButton": {
     "description": "Create report - button text"
+  },
+
+  "newprojectPage_title": "Create new project",
+  "@newprojectPage_title": {
+    "description": "Create new project - title"
   },
 
   "loadingDialog_analyzing": "Analyzing your aereal images",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -155,9 +155,19 @@
     "description": "Last opp SOSI fil - text"
   },
 
+  "createPage_uploadWaterSOSIFile": "Last opp SOSI vannpolygon fil",
+  "@createPage_uploadWaterSOSIFile": {
+    "description": "Last opp SOSI vannpolygon fil - text"
+  },
+
   "createPage_createReportButton": "Lag rapport",
   "@createPage_createReportButton": {
     "description": "Lag rapport - button text"
+  },
+
+  "newprojectPage_title": "Opprett nytt prosjekt",
+  "@newprojectPage_title": {
+    "description": "Create new project - title"
   },
 
   "loadingDialog_analyzing": "Analyserer luftbildene dine",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -72,6 +72,11 @@
     "description": "Project"
   },
 
+  "g_noImagesProcessed": "Ingen bilder analysert enda",
+  "@g_noImagesProcessed": {
+    "description": "No images processed - text when no images have been processed yet"
+  },
+
   "settings_title": "Innstillinger",
   "@settings_title": {},
 
@@ -228,6 +233,31 @@
   "anomalyClassifBar_searchCreate": "Søk eller opprett avvikstype",
   "@anomalyClassifBar_searchCreate": {
     "description": "Søk eller opprett avvikstype - text input hint"
+  },
+
+  "projectOverview_projectName": "Prosjektnavn",
+  "@projectOverview_projectName": {
+    "description": "Project name - label for project name in project overview"
+  },
+
+  "projectOverview_noWaterSosi": "Ingen SOSI fil for vann knyttet til prosjekt",
+  "@projectOverview_noWaterSosi": {
+    "description": "Sosi water polygon file is missing - text when no water sosi file is linked to project"
+  },
+
+  "projectOverview_imagesPresent": "Antall bilder i mappe",
+  "@projectOverview_imagesPresent": {
+    "description": "Number of images present in folder"
+  },
+
+  "projectOverview_imagesProcessed": "Antall bilder analysert",
+  "@projectOverview_imagesProcessed": {
+    "description": "Number of images processed"
+  },
+
+  "projectOverview_lastImageProcessed": "Siste bilde analysert",
+  "@projectOverview_lastImageProcessed": {
+    "description": "Last image that has been processed"
   }
 
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -62,6 +62,11 @@
     "description": "Bekreft"
   },
 
+  "g_project": "Prosjekt",
+  "@g_project": {
+    "description": "Project"
+  },
+
   "settings_title": "Innstillinger",
   "@settings_title": {},
 

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -16,6 +16,11 @@
     "description": "Share something"
   },
 
+  "g_close": "Lukk",
+  "@g_close": {
+    "description": "Close something"
+  },
+
   "g_file": "Fil",
   "@g_file": {
     "description": "Used as a menu item for file, but also as file in general"

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -21,6 +21,11 @@
     "description": "Used as a menu item for file, but also as file in general"
   },
 
+  "g_browse": "Bla Gjennom",
+  "@g_browse": {
+    "description": "Used for browsing, mainly for upload buttons"
+  },
+
   "g_settings": "Innstillinger",
   "@g_settings": {
     "description": "Used as a menu item for settings, but also as settings in general"
@@ -145,19 +150,29 @@
     "description": "Tittel - input field"
   },
 
-  "createPage_uploadPlaneImages": "Last opp flybilder",
+  "createPage_uploadPlaneImages": "Flybildemappe",
   "@createPage_uploadPlaneImages": {
     "description": "Last opp flybilder - text"
   },
 
-  "createPage_uploadSOSIFile": "Last opp SOSI fil",
+  "createPage_uploadSOSIFile": "Dekningspolygon SOSI",
   "@createPage_uploadSOSIFile": {
     "description": "Last opp SOSI fil - text"
   },
 
-  "createPage_uploadWaterSOSIFile": "Last opp SOSI vannpolygon fil",
+  "createPage_uploadWaterSOSIFile": "Vannpolygon SOSI",
   "@createPage_uploadWaterSOSIFile": {
     "description": "Last opp SOSI vannpolygon fil - text"
+  },
+
+  "createPage_noFile": "Ingen fil valgt",
+  "@createPage_noFile": {
+    "description": "Ingen fil valgt - text when no file is chosen"
+  },
+
+  "createPage_noFolder": "Ingen mappe valgt",
+  "@createPage_noFolder": {
+    "description": "Ingen mappe valgt - text when no folder is chosen"
   },
 
   "createPage_createReportButton": "Lag rapport",
@@ -168,6 +183,21 @@
   "newprojectPage_title": "Opprett nytt prosjekt",
   "@newprojectPage_title": {
     "description": "Create new project - title"
+  },
+
+  "newprojectPage_Missingproject": "Mangler prosjektnavn",
+  "@newprojectPage_Missingproject": {
+    "description": "Missing project name from form"
+  },
+
+  "newprojectPage_Missingaerial": "Mangler flybildemappe",
+  "@newprojectPage_Missingaerial": {
+    "description": "Missing aerial images from form"
+  },
+
+  "newprojectPage_Missingsosi": "Mangler dekningspolygon SOSI",
+  "@newprojectPage_Missingsosi": {
+    "description": "Missing polygon SOSI from form"
   },
 
   "loadingDialog_analyzing": "Analyserer luftbildene dine",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,13 +3,13 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:skavl/model/settings_model.dart';
 import 'package:skavl/pages/create_new_project.dart';
+import 'package:skavl/pages/project_overview.dart';
 import 'package:skavl/services/anomaly_service_provider.dart';
 import 'package:skavl/services/project_manager_service.dart';
 import 'package:skavl/services/service_manager.dart';
 import 'package:skavl/theme/app_themes.dart';
 import 'package:skavl/util/navigation_util.dart';
 import 'package:skavl/util/project_actions.dart';
-import 'package:skavl/widgets/anomaly_classif_bar.dart';
 import 'package:skavl/widgets/bottom_status_bar.dart';
 import 'package:skavl/widgets/top_bar.dart';
 import 'l10n/app_localizations.dart';
@@ -102,6 +102,12 @@ class _MainPageState extends State<MainPage> {
 
   @override
   Widget build(BuildContext context) {
+    final projectManager = context.watch<ProjectManagerService>();
+
+    if (projectManager.loadedProject != null) {
+      return ProjectOverview();
+    }
+
     return MyHomePage(title: "title");
   }
 }
@@ -158,8 +164,7 @@ class _MyHomePageState extends State<MyHomePage> {
       bottomNavigationBar: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          AnomalyClassifBar(),
-          BottomStatusBar(foreignContext: context),
+          BottomStatusBar(),
         ],
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,10 +2,13 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:skavl/model/settings_model.dart';
+import 'package:skavl/pages/create_new_project.dart';
 import 'package:skavl/services/anomaly_service_provider.dart';
 import 'package:skavl/services/project_manager_service.dart';
 import 'package:skavl/services/service_manager.dart';
 import 'package:skavl/theme/app_themes.dart';
+import 'package:skavl/util/navigation_util.dart';
+import 'package:skavl/util/project_actions.dart';
 import 'package:skavl/widgets/anomaly_classif_bar.dart';
 import 'package:skavl/widgets/bottom_status_bar.dart';
 import 'package:skavl/widgets/top_bar.dart';
@@ -113,7 +116,6 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-
   AppLocalizations? loc() {
     return AppLocalizations.of(context);
   }
@@ -134,9 +136,14 @@ class _MyHomePageState extends State<MyHomePage> {
                   mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                   children: [
                     LargeHeader(loc()!.welcomePage_SKAVL),
-                    LongButton(loc()!.welcomePage_openFormer),
-                    LongButton(loc()!.welcomePage_createNewButton),
-                    // Text(context.watch<ProjectManagerService>().loadedProject!.projectName)
+                    LongButton(
+                      loc()!.welcomePage_openFormer,
+                      onPressed: () => ProjectActions.openProject(context),
+                    ),
+                    LongButton(
+                      loc()!.welcomePage_createNewButton,
+                      onPressed: () => navigateTo(context, CreateNewProject()),
+                    ),
                   ],
                 ),
                 const Image(
@@ -152,7 +159,7 @@ class _MyHomePageState extends State<MyHomePage> {
         mainAxisSize: MainAxisSize.min,
         children: [
           AnomalyClassifBar(),
-          BottomStatusBar(foreignContext: context,)
+          BottomStatusBar(foreignContext: context),
         ],
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:grpc/grpc.dart';
 import 'package:skavl/model/settings_model.dart';
 import 'package:skavl/proto/anomaly.pbgrpc.dart';
 import 'package:skavl/services/anomaly_service_provider.dart';
+import 'package:skavl/services/project_manager_service.dart';
 import 'package:skavl/services/service_manager.dart';
 import 'package:skavl/theme/app_themes.dart';
 import 'package:skavl/widgets/anomaly_classif_bar.dart';
@@ -20,6 +21,7 @@ void main() {
     MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => SettingsModel()),
+        ChangeNotifierProvider(create: (_) => ProjectManagerService()),
         ChangeNotifierProvider(create: (_) => AnomalyServiceProvider()),
       ],
       child: const MyApp(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:skavl/services/project_manager_service.dart';
 import 'package:skavl/services/service_manager.dart';
 import 'package:skavl/theme/app_themes.dart';
 import 'package:skavl/widgets/anomaly_classif_bar.dart';
+import 'package:skavl/widgets/bottom_status_bar.dart';
 import 'package:skavl/widgets/top_bar.dart';
 import 'l10n/app_localizations.dart';
 import 'package:skavl/widgets/long_button.dart';
@@ -147,7 +148,13 @@ class _MyHomePageState extends State<MyHomePage> {
           ],
         ),
       ),
-      bottomNavigationBar: AnomalyClassifBar(),
+      bottomNavigationBar: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AnomalyClassifBar(),
+          BottomStatusBar(foreignContext: context,)
+        ],
+      ),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:grpc/grpc.dart';
 import 'package:skavl/model/settings_model.dart';
-import 'package:skavl/proto/anomaly.pbgrpc.dart';
 import 'package:skavl/services/anomaly_service_provider.dart';
 import 'package:skavl/services/project_manager_service.dart';
 import 'package:skavl/services/service_manager.dart';
@@ -114,8 +112,6 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  late final ClientChannel channel;
-  late final AnomalyDetectorServiceClient anomalyClient;
 
   AppLocalizations? loc() {
     return AppLocalizations.of(context);
@@ -139,6 +135,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     LargeHeader(loc()!.welcomePage_SKAVL),
                     LongButton(loc()!.welcomePage_openFormer),
                     LongButton(loc()!.welcomePage_createNewButton),
+                    // Text(context.watch<ProjectManagerService>().loadedProject!.projectName)
                   ],
                 ),
                 const Image(

--- a/lib/pages/create_new_project.dart
+++ b/lib/pages/create_new_project.dart
@@ -49,21 +49,21 @@ class _CreateNewProjectState extends State<CreateNewProject> {
     final sosiWaterPath = _sosiWaterFilePath;
 
     if (_titleController.text.isEmpty) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(loc()!.newprojectPage_Missingproject)));
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(loc()!.newprojectPage_Missingproject)),
+      );
       return;
     }
     if (imagePath == null) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(loc()!.newprojectPage_Missingaerial)));
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(loc()!.newprojectPage_Missingaerial)),
+      );
       return;
     }
     if (sosiPath == null) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(loc()!.newprojectPage_Missingsosi)));
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(loc()!.newprojectPage_Missingsosi)),
+      );
       return;
     }
 
@@ -92,7 +92,6 @@ class _CreateNewProjectState extends State<CreateNewProject> {
 
   @override
   Widget build(BuildContext context) {
-
     return Scaffold(
       body: Padding(
         padding: const EdgeInsets.all(32.0),
@@ -101,7 +100,7 @@ class _CreateNewProjectState extends State<CreateNewProject> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             LargeHeader(loc()!.newprojectPage_title),
-            SizedBox(height: 32,),
+            SizedBox(height: 32),
             Expanded(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.start,
@@ -113,7 +112,7 @@ class _CreateNewProjectState extends State<CreateNewProject> {
                       labelText: loc()!.createPage_titleInput,
                     ),
                   ),
-                  SizedBox(height: 16,),
+                  SizedBox(height: 16),
 
                   // Upload boxes
                   UploadButton(
@@ -141,40 +140,36 @@ class _CreateNewProjectState extends State<CreateNewProject> {
                   Spacer(),
 
                   // Create report button
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    // crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      SizedBox(
-                        height: 48,
-                        child: ElevatedButton(
-                          onPressed: _createProject,
-                          child: Row(
-                            spacing: 16,
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Text(
-                                loc()!.newprojectPage_title,
-                                style: Theme.of(
-                                  context,
-                                ).textTheme.bodyMedium,
-                              ),
-                              Icon(
-                                Icons.arrow_forward_ios_outlined,
-                                size: 20,
-                                color:
-                                    Theme.of(context).brightness ==
-                                        Brightness.light
-                                    ? MyColors.secondaryBlack
-                                    : MyColors.primaryWhite,
-                              ),
-                            ],
-                          ),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: SizedBox(
+                      height: 48,
+                      child: ElevatedButton(
+                        onPressed: _createProject,
+                        child: Row(
+                          spacing: 16,
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              loc()!.newprojectPage_title,
+                              style: Theme.of(context).textTheme.bodyMedium,
+                            ),
+                            Icon(
+                              Icons.arrow_forward_ios_outlined,
+                              size: 20,
+                              color:
+                                  Theme.of(context).brightness == Brightness.light
+                                  ? MyColors.secondaryBlack
+                                  : MyColors.primaryWhite,
+                            ),
+                          ],
                         ),
                       ),
-                    ],
+                    ),
                   ),
-                  SizedBox(height: 48,)
+
+                  SizedBox(height: 8),
                 ],
               ),
             ),

--- a/lib/pages/create_new_project.dart
+++ b/lib/pages/create_new_project.dart
@@ -2,14 +2,14 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:skavl/l10n/app_localizations.dart';
-import 'package:skavl/services/anomaly_service_provider.dart';
+import 'package:skavl/main.dart';
 import 'package:skavl/services/project_manager_service.dart';
 import 'package:skavl/theme/colors.dart';
+import 'package:skavl/util/navigation_util.dart';
 import 'package:skavl/widgets/bottom_status_bar.dart';
 import 'package:skavl/widgets/labels/headings.dart';
 import 'package:skavl/widgets/top_bar.dart';
-import 'package:skavl/widgets/upload.dart';
-import 'package:skavl/widgets/dialogs/loading_popup.dart';
+import 'package:skavl/widgets/upload_button.dart';
 
 import '../entity/project_metadata.dart';
 import '../services/project_file_service.dart';
@@ -51,19 +51,19 @@ class _CreateNewProjectState extends State<CreateNewProject> {
     if (_titleController.text.isEmpty) {
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text("Missing project name")));
+      ).showSnackBar(SnackBar(content: Text(loc()!.newprojectPage_Missingproject)));
       return;
     }
     if (imagePath == null) {
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text("Missing image folder path")));
+      ).showSnackBar(SnackBar(content: Text(loc()!.newprojectPage_Missingaerial)));
       return;
     }
     if (sosiPath == null) {
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text("Missing SOSI file")));
+      ).showSnackBar(SnackBar(content: Text(loc()!.newprojectPage_Missingsosi)));
       return;
     }
 
@@ -87,150 +87,95 @@ class _CreateNewProjectState extends State<CreateNewProject> {
     if (!mounted) return;
 
     context.read<ProjectManagerService>().setProject(project, savePath);
-  }
-
-  // Method for picking an image folder
-  Future<void> _pickImageFolder() async {
-    final path = await FilePicker.getDirectoryPath();
-    if (path != null) {
-      setState(() => _imageFolderPath = path);
-    }
-  }
-
-  // Method for picking SOSI file, needs to be refactored to set param so it can be reused for water mask sosi.
-  Future<String?> _pickSosiFile() async {
-    final result = await FilePicker.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: ['sos'],
-    );
-    if (result != null) {
-      return result.files.single.path;
-    }
-    return null;
+    navigateTo(context, MainPage());
   }
 
   @override
   Widget build(BuildContext context) {
-    final containerWidth = MediaQuery.of(context).size.width * 0.9;
 
     return Scaffold(
-      body: Center(
+      body: Padding(
+        padding: const EdgeInsets.all(32.0),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.start,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            SizedBox(height: 40),
-            Padding(
-              padding: const EdgeInsets.all(10.0),
-              child: LargeHeader(loc()!.newprojectPage_title),
-            ),
+            LargeHeader(loc()!.newprojectPage_title),
+            SizedBox(height: 32,),
             Expanded(
-              child: Padding(
-                padding: const EdgeInsets.all(10.0),
-                child: Container(
-                  alignment: Alignment.topLeft,
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(5),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                spacing: 16,
+                children: [
+                  TextField(
+                    controller: _titleController,
+                    decoration: InputDecoration(
+                      labelText: loc()!.createPage_titleInput,
+                    ),
                   ),
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.start,
+                  SizedBox(height: 16,),
+
+                  // Upload boxes
+                  UploadButton(
+                    label: loc()!.createPage_uploadPlaneImages,
+                    isRequired: true,
+                    selectedPath: _imageFolderPath,
+                    onPathSelected: (value) =>
+                        setState(() => _imageFolderPath = value),
+                    isFolder: true,
+                  ),
+                  UploadButton(
+                    label: loc()!.createPage_uploadSOSIFile,
+                    isRequired: true,
+                    selectedPath: _sosiFilePath,
+                    onPathSelected: (value) =>
+                        setState(() => _sosiFilePath = value),
+                  ),
+                  UploadButton(
+                    label: loc()!.createPage_uploadWaterSOSIFile,
+                    selectedPath: _sosiWaterFilePath,
+                    onPathSelected: (value) =>
+                        setState(() => _sosiWaterFilePath = value),
+                  ),
+
+                  Spacer(),
+
+                  // Create report button
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    // crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      TextField(
-                        controller: _titleController,
-                        decoration: InputDecoration(
-                          labelText: loc()!.createPage_titleInput,
-                        ),
-                      ),
-
-                      // Upload boxes
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Expanded(
-                            child: UploadBox(
-                              text:
-                                  _imageFolderPath ??
-                                  loc()!.createPage_uploadPlaneImages,
-                              onTap: _pickImageFolder,
-                            ),
-                          ),
-                          Expanded(
-                            child: Padding(
-                              padding: const EdgeInsets.all(8.0),
-                              child: UploadBox(
-                                text:
-                                    _sosiFilePath ??
-                                    loc()!.createPage_uploadSOSIFile,
-                                onTap: () async {
-                                  final path = await _pickSosiFile();
-                                  if (path != null) {
-                                    setState(() {
-                                      _sosiFilePath = path;
-                                    });
-                                  }
-                                },
+                      SizedBox(
+                        height: 48,
+                        child: ElevatedButton(
+                          onPressed: _createProject,
+                          child: Row(
+                            spacing: 16,
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Text(
+                                loc()!.newprojectPage_title,
+                                style: Theme.of(
+                                  context,
+                                ).textTheme.bodyMedium,
                               ),
-                            ),
-                          ),
-                          Expanded(
-                            child: Padding(
-                              padding: const EdgeInsets.all(8.0),
-                              child: UploadBox(
-                                text:
-                                    _sosiWaterFilePath ??
-                                    loc()!.createPage_uploadSOSIFile,
-                                onTap: () async {
-                                  final path = await _pickSosiFile();
-                                  if (path != null) {
-                                    setState(() {
-                                      _sosiWaterFilePath = path;
-                                    });
-                                  }
-                                },
+                              Icon(
+                                Icons.arrow_forward_ios_outlined,
+                                size: 20,
+                                color:
+                                    Theme.of(context).brightness ==
+                                        Brightness.light
+                                    ? MyColors.secondaryBlack
+                                    : MyColors.primaryWhite,
                               ),
-                            ),
+                            ],
                           ),
-                        ],
-                      ),
-
-                      Spacer(),
-
-                      // Create report button
-                      Padding(
-                        padding: const EdgeInsets.all(8.0),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.end,
-                          children: [
-                            ElevatedButton(
-                              onPressed: _createProject,
-                              child: Row(
-                                spacing: 8,
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: [
-                                  Text(
-                                    loc()!.createPage_createReportButton,
-                                    style: Theme.of(
-                                      context,
-                                    ).textTheme.bodyMedium,
-                                  ),
-                                  Icon(
-                                    Icons.arrow_forward_ios_outlined,
-                                    size: 20,
-                                    color:
-                                        Theme.of(context).brightness ==
-                                            Brightness.light
-                                        ? MyColors.secondaryBlack
-                                        : MyColors.primaryWhite,
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ],
                         ),
                       ),
                     ],
                   ),
-                ),
+                  SizedBox(height: 48,)
+                ],
               ),
             ),
           ],

--- a/lib/pages/create_new_project.dart
+++ b/lib/pages/create_new_project.dart
@@ -139,7 +139,7 @@ class _CreateNewProjectState extends State<CreateNewProject> {
 
                   Spacer(),
 
-                  // Create report button
+                  // Create project button
                   Align(
                     alignment: Alignment.centerRight,
                     child: SizedBox(
@@ -177,7 +177,7 @@ class _CreateNewProjectState extends State<CreateNewProject> {
         ),
       ),
       appBar: TopBar(foreignContext: context),
-      bottomNavigationBar: BottomStatusBar(foreignContext: context),
+      bottomNavigationBar: BottomStatusBar(),
     );
   }
 }

--- a/lib/pages/create_new_project.dart
+++ b/lib/pages/create_new_project.dart
@@ -1,0 +1,243 @@
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:skavl/l10n/app_localizations.dart';
+import 'package:skavl/services/anomaly_service_provider.dart';
+import 'package:skavl/services/project_manager_service.dart';
+import 'package:skavl/theme/colors.dart';
+import 'package:skavl/widgets/bottom_status_bar.dart';
+import 'package:skavl/widgets/labels/headings.dart';
+import 'package:skavl/widgets/top_bar.dart';
+import 'package:skavl/widgets/upload.dart';
+import 'package:skavl/widgets/dialogs/loading_popup.dart';
+
+import '../entity/project_metadata.dart';
+import '../services/project_file_service.dart';
+
+class CreateNewProject extends StatefulWidget {
+  const CreateNewProject({super.key});
+
+  @override
+  State<CreateNewProject> createState() => _CreateNewProjectState();
+}
+
+class _CreateNewProjectState extends State<CreateNewProject> {
+  AppLocalizations? loc() {
+    return AppLocalizations.of(context);
+  }
+
+  late TextEditingController _titleController;
+  String? _imageFolderPath;
+  String? _sosiFilePath;
+  String? _sosiWaterFilePath;
+
+  @override
+  void initState() {
+    super.initState();
+    _titleController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _createProject() async {
+    final imagePath = _imageFolderPath;
+    final sosiPath = _sosiFilePath;
+    final sosiWaterPath = _sosiWaterFilePath;
+
+    if (_titleController.text.isEmpty) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text("Missing project name")));
+      return;
+    }
+    if (imagePath == null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text("Missing image folder path")));
+      return;
+    }
+    if (sosiPath == null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text("Missing SOSI file")));
+      return;
+    }
+
+    final savePath = await FilePicker.saveFile(
+      dialogTitle: 'Save project',
+      fileName: '${_titleController.text}.skavl',
+      type: FileType.custom,
+      allowedExtensions: ['skavl'],
+    );
+
+    if (savePath == null) return; // user cancelled
+
+    final project = ProjectMetadata(
+      projectName: _titleController.text,
+      sosiFilePath: sosiPath,
+      imageFolderPath: imagePath,
+      sosiWaterMaskPath: sosiWaterPath,
+    );
+
+    await ProjectFileService().saveToFile(savePath, project);
+    if (!mounted) return;
+
+    context.read<ProjectManagerService>().setProject(project, savePath);
+  }
+
+  // Method for picking an image folder
+  Future<void> _pickImageFolder() async {
+    final path = await FilePicker.getDirectoryPath();
+    if (path != null) {
+      setState(() => _imageFolderPath = path);
+    }
+  }
+
+  // Method for picking SOSI file, needs to be refactored to set param so it can be reused for water mask sosi.
+  Future<String?> _pickSosiFile() async {
+    final result = await FilePicker.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['sos'],
+    );
+    if (result != null) {
+      return result.files.single.path;
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final containerWidth = MediaQuery.of(context).size.width * 0.9;
+
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(height: 40),
+            Padding(
+              padding: const EdgeInsets.all(10.0),
+              child: LargeHeader(loc()!.newprojectPage_title),
+            ),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.all(10.0),
+                child: Container(
+                  alignment: Alignment.topLeft,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(5),
+                  ),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    children: [
+                      TextField(
+                        controller: _titleController,
+                        decoration: InputDecoration(
+                          labelText: loc()!.createPage_titleInput,
+                        ),
+                      ),
+
+                      // Upload boxes
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Expanded(
+                            child: UploadBox(
+                              text:
+                                  _imageFolderPath ??
+                                  loc()!.createPage_uploadPlaneImages,
+                              onTap: _pickImageFolder,
+                            ),
+                          ),
+                          Expanded(
+                            child: Padding(
+                              padding: const EdgeInsets.all(8.0),
+                              child: UploadBox(
+                                text:
+                                    _sosiFilePath ??
+                                    loc()!.createPage_uploadSOSIFile,
+                                onTap: () async {
+                                  final path = await _pickSosiFile();
+                                  if (path != null) {
+                                    setState(() {
+                                      _sosiFilePath = path;
+                                    });
+                                  }
+                                },
+                              ),
+                            ),
+                          ),
+                          Expanded(
+                            child: Padding(
+                              padding: const EdgeInsets.all(8.0),
+                              child: UploadBox(
+                                text:
+                                    _sosiWaterFilePath ??
+                                    loc()!.createPage_uploadSOSIFile,
+                                onTap: () async {
+                                  final path = await _pickSosiFile();
+                                  if (path != null) {
+                                    setState(() {
+                                      _sosiWaterFilePath = path;
+                                    });
+                                  }
+                                },
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+
+                      Spacer(),
+
+                      // Create report button
+                      Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          children: [
+                            ElevatedButton(
+                              onPressed: _createProject,
+                              child: Row(
+                                spacing: 8,
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Text(
+                                    loc()!.createPage_createReportButton,
+                                    style: Theme.of(
+                                      context,
+                                    ).textTheme.bodyMedium,
+                                  ),
+                                  Icon(
+                                    Icons.arrow_forward_ios_outlined,
+                                    size: 20,
+                                    color:
+                                        Theme.of(context).brightness ==
+                                            Brightness.light
+                                        ? MyColors.secondaryBlack
+                                        : MyColors.primaryWhite,
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      appBar: TopBar(foreignContext: context),
+      bottomNavigationBar: BottomStatusBar(foreignContext: context),
+    );
+  }
+}

--- a/lib/pages/create_new_report.dart
+++ b/lib/pages/create_new_report.dart
@@ -1,8 +1,6 @@
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:skavl/l10n/app_localizations.dart';
-import 'package:skavl/services/anomaly_service_provider.dart';
 import 'package:skavl/theme/colors.dart';
 import 'package:skavl/widgets/labels/headings.dart';
 import 'package:skavl/widgets/top_bar.dart';
@@ -48,42 +46,6 @@ class _CreateNewReportPageState extends State<CreateNewReportPage> {
 
     // Hide dialog
     LoadingDialog.hide(context);
-  }
-
-  // Temporary method for testing anomaly detection start based on selected params
-  Future<void> _startAnomalyDetection() async {
-    final imagePath = _imageFolderPath;
-    final sosiPath = _sosiFilePath;
-
-    if (_titleController.text.isEmpty) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text("Missing project name")));
-      return;
-    }
-    if (imagePath == null) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text("Missing image folder path")));
-      return;
-    }
-    if (sosiPath == null) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text("Missing SOSI file")));
-      return;
-    }
-    context.read<AnomalyServiceProvider>().controller.getProjectInfo(
-      projectName: _titleController.text,
-      imagePath: imagePath,
-      sosiPath: sosiPath,
-    );
-
-    context.read<AnomalyServiceProvider>().controller.runAnalysis(
-      projectName: _titleController.text,
-      imagePath: imagePath,
-      sosiPath: sosiPath,
-    );
   }
 
   // Method for picking an image folder

--- a/lib/pages/create_new_report.dart
+++ b/lib/pages/create_new_report.dart
@@ -3,11 +3,15 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:skavl/l10n/app_localizations.dart';
 import 'package:skavl/services/anomaly_service_provider.dart';
+import 'package:skavl/services/project_manager_service.dart';
 import 'package:skavl/theme/colors.dart';
 import 'package:skavl/widgets/labels/headings.dart';
 import 'package:skavl/widgets/top_bar.dart';
 import 'package:skavl/widgets/upload.dart';
 import 'package:skavl/widgets/dialogs/loading_popup.dart';
+
+import '../entity/project_metadata.dart';
+import '../services/project_file_service.dart';
 
 class CreateNewReportPage extends StatefulWidget {
   const CreateNewReportPage({super.key});
@@ -73,19 +77,62 @@ class _CreateNewReportPageState extends State<CreateNewReportPage> {
       ).showSnackBar(SnackBar(content: Text("Missing SOSI file")));
       return;
     }
-    context
-        .read<AnomalyServiceProvider>()
-        .controller
-        .getProjectInfo(projectName: _titleController.text,
-        imagePath: imagePath,
-        sosiPath: sosiPath);
+    context.read<AnomalyServiceProvider>().controller.getProjectInfo(
+      projectName: _titleController.text,
+      imagePath: imagePath,
+      sosiPath: sosiPath,
+    );
 
-    context
-        .read<AnomalyServiceProvider>()
-        .controller
-        .runAnalysis(projectName: _titleController.text,
-        imagePath: imagePath,
-        sosiPath: sosiPath);
+    context.read<AnomalyServiceProvider>().controller.runAnalysis(
+      projectName: _titleController.text,
+      imagePath: imagePath,
+      sosiPath: sosiPath,
+    );
+  }
+
+  Future<void> _createProject() async {
+    final imagePath = _imageFolderPath;
+    final sosiPath = _sosiFilePath;
+
+    if (_titleController.text.isEmpty) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text("Missing project name")));
+      return;
+    }
+    if (imagePath == null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text("Missing image folder path")));
+      return;
+    }
+    if (sosiPath == null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text("Missing SOSI file")));
+      return;
+    }
+
+    final savePath = await FilePicker.saveFile(
+      dialogTitle: 'Save project',
+      fileName: '${_titleController.text}.skavl',
+      type: FileType.custom,
+      allowedExtensions: ['skavl'],
+    );
+
+    if (savePath == null) return; // user cancelled
+
+    final project = ProjectMetadata(
+      projectName: _titleController.text,
+      sosiFilePath: sosiPath,
+      imageFolderPath: imagePath,
+    );
+
+    await ProjectFileService().saveToFile(savePath, project);
+    if (!mounted) return;
+
+    context.read<ProjectManagerService>().setProject(project, savePath);
+
   }
 
   // Method for picking an image folder
@@ -109,19 +156,10 @@ class _CreateNewReportPageState extends State<CreateNewReportPage> {
 
   @override
   Widget build(BuildContext context) {
-    final containerWidth = MediaQuery
-        .of(context)
-        .size
-        .width * 0.9;
+    final containerWidth = MediaQuery.of(context).size.width * 0.9;
     final titleStart =
-        (MediaQuery
-            .of(context)
-            .size
-            .width - containerWidth) * 0.5;
-    final containerHeight = MediaQuery
-        .of(context)
-        .size
-        .height * 0.8;
+        (MediaQuery.of(context).size.width - containerWidth) * 0.5;
+    final containerHeight = MediaQuery.of(context).size.height * 0.8;
 
     return Scaffold(
       body: Center(
@@ -169,14 +207,14 @@ class _CreateNewReportPageState extends State<CreateNewReportPage> {
                         children: [
                           UploadBox(
                             text:
-                            _imageFolderPath ??
+                                _imageFolderPath ??
                                 loc()!.createPage_uploadPlaneImages,
                             onTap: _pickImageFolder,
                             width: containerWidth * 0.5 - 20,
                           ),
                           UploadBox(
                             text:
-                            _sosiFilePath ??
+                                _sosiFilePath ??
                                 loc()!.createPage_uploadSOSIFile,
                             onTap: _pickSosiFile,
                             width: containerWidth * 0.5 - 20,
@@ -223,26 +261,21 @@ class _CreateNewReportPageState extends State<CreateNewReportPage> {
 
                           // Button to test anomaly detection, commented out spinner for now.
                           ElevatedButton(
-                            onPressed: _startAnomalyDetection,
+                            onPressed: _createProject,
                             child: Row(
                               spacing: 8,
                               mainAxisAlignment: MainAxisAlignment.center,
                               children: [
                                 Text(
                                   loc()!.createPage_createReportButton,
-                                  style: Theme
-                                      .of(context)
-                                      .textTheme
-                                      .bodyMedium,
+                                  style: Theme.of(context).textTheme.bodyMedium,
                                 ),
                                 Icon(
                                   Icons.arrow_forward_ios_outlined,
                                   size: 20,
                                   color:
-                                  Theme
-                                      .of(context)
-                                      .brightness ==
-                                      Brightness.light
+                                      Theme.of(context).brightness ==
+                                          Brightness.light
                                       ? MyColors.secondaryBlack
                                       : MyColors.primaryWhite,
                                 ),

--- a/lib/pages/create_new_report.dart
+++ b/lib/pages/create_new_report.dart
@@ -3,15 +3,11 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:skavl/l10n/app_localizations.dart';
 import 'package:skavl/services/anomaly_service_provider.dart';
-import 'package:skavl/services/project_manager_service.dart';
 import 'package:skavl/theme/colors.dart';
 import 'package:skavl/widgets/labels/headings.dart';
 import 'package:skavl/widgets/top_bar.dart';
 import 'package:skavl/widgets/upload.dart';
 import 'package:skavl/widgets/dialogs/loading_popup.dart';
-
-import '../entity/project_metadata.dart';
-import '../services/project_file_service.dart';
 
 class CreateNewReportPage extends StatefulWidget {
   const CreateNewReportPage({super.key});
@@ -88,51 +84,6 @@ class _CreateNewReportPageState extends State<CreateNewReportPage> {
       imagePath: imagePath,
       sosiPath: sosiPath,
     );
-  }
-
-  Future<void> _createProject() async {
-    final imagePath = _imageFolderPath;
-    final sosiPath = _sosiFilePath;
-
-    if (_titleController.text.isEmpty) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text("Missing project name")));
-      return;
-    }
-    if (imagePath == null) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text("Missing image folder path")));
-      return;
-    }
-    if (sosiPath == null) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text("Missing SOSI file")));
-      return;
-    }
-
-    final savePath = await FilePicker.saveFile(
-      dialogTitle: 'Save project',
-      fileName: '${_titleController.text}.skavl',
-      type: FileType.custom,
-      allowedExtensions: ['skavl'],
-    );
-
-    if (savePath == null) return; // user cancelled
-
-    final project = ProjectMetadata(
-      projectName: _titleController.text,
-      sosiFilePath: sosiPath,
-      imageFolderPath: imagePath,
-    );
-
-    await ProjectFileService().saveToFile(savePath, project);
-    if (!mounted) return;
-
-    context.read<ProjectManagerService>().setProject(project, savePath);
-
   }
 
   // Method for picking an image folder
@@ -231,57 +182,34 @@ class _CreateNewReportPageState extends State<CreateNewReportPage> {
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.end,
                         children: [
-                          // ElevatedButton(
-                          //   onPressed: startLoadingModal,
-                          //   child: Row(
-                          //     spacing: 8,
-                          //     mainAxisAlignment: MainAxisAlignment.center,
-                          //     children: [
-                          //       Text(
-                          //         loc()!.createPage_createReportButton,
-                          //         style: Theme
-                          //             .of(context)
-                          //             .textTheme
-                          //             .bodyMedium,
-                          //       ),
-                          //       Icon(
-                          //         Icons.arrow_forward_ios_outlined,
-                          //         size: 20,
-                          //         color:
-                          //         Theme
-                          //             .of(context)
-                          //             .brightness ==
-                          //             Brightness.light
-                          //             ? MyColors.secondaryBlack
-                          //             : MyColors.primaryWhite,
-                          //       ),
-                          //     ],
-                          //   ),
-                          // ),
-
-                          // Button to test anomaly detection, commented out spinner for now.
                           ElevatedButton(
-                            onPressed: _createProject,
+                            onPressed: startLoadingModal,
                             child: Row(
                               spacing: 8,
                               mainAxisAlignment: MainAxisAlignment.center,
                               children: [
                                 Text(
                                   loc()!.createPage_createReportButton,
-                                  style: Theme.of(context).textTheme.bodyMedium,
+                                  style: Theme
+                                      .of(context)
+                                      .textTheme
+                                      .bodyMedium,
                                 ),
                                 Icon(
                                   Icons.arrow_forward_ios_outlined,
                                   size: 20,
                                   color:
-                                      Theme.of(context).brightness ==
-                                          Brightness.light
+                                  Theme
+                                      .of(context)
+                                      .brightness ==
+                                      Brightness.light
                                       ? MyColors.secondaryBlack
                                       : MyColors.primaryWhite,
                                 ),
                               ],
                             ),
                           ),
+
                         ],
                       ),
                     ),

--- a/lib/pages/project_overview.dart
+++ b/lib/pages/project_overview.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:skavl/services/project_manager_service.dart';
+import 'package:skavl/widgets/bottom_status_bar.dart';
+import 'package:skavl/widgets/labels/fieldlabels.dart';
+import 'package:skavl/widgets/labels/headings.dart';
+
+import '../l10n/app_localizations.dart';
+import '../proto/anomaly.pb.dart';
+import '../services/anomaly_service_provider.dart';
+import '../theme/colors.dart';
+import '../widgets/top_bar.dart';
+
+class ProjectOverview extends StatefulWidget {
+  const ProjectOverview({super.key});
+
+  @override
+  State<ProjectOverview> createState() => _ProjectOverviewState();
+}
+
+class _ProjectOverviewState extends State<ProjectOverview> {
+  DescribeAnomalyProjectResponse? _projectInfo;
+  bool _isLoading = true;
+
+  // Temporary method for testing anomaly detection start based on selected params
+  Future<void> _startAnomalyDetection(
+    ProjectManagerService projectManager,
+  ) async {
+    final imagePath = projectManager.loadedProject!.imageFolderPath;
+    final sosiPath = projectManager.loadedProject!.sosiFilePath;
+
+    context
+        .read<AnomalyServiceProvider>()
+        .controller
+        .runAnalysis(
+          projectName: projectManager.loadedProject!.projectName,
+          imagePath: imagePath,
+          sosiPath: sosiPath,
+        );
+  }
+
+  Future<void> _loadProjectInfo() async {
+    final projectManager = context.read<ProjectManagerService>();
+    final result = await context
+        .read<AnomalyServiceProvider>()
+        .controller
+        .getProjectInfo(
+          projectName: projectManager.loadedProject!.projectName,
+          imagePath: projectManager.loadedProject!.imageFolderPath,
+          sosiPath: projectManager.loadedProject!.sosiFilePath,
+        );
+
+    setState(() {
+      _projectInfo = result;
+      _isLoading = false;
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _loadProjectInfo();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ProjectManagerService projectManager = context
+        .read<ProjectManagerService>();
+    final loc = AppLocalizations.of(context);
+
+    return Scaffold(
+      appBar: TopBar(foreignContext: context),
+      body: Padding(
+        padding: const EdgeInsets.all(32.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          spacing: 32,
+          children: [
+            LargeHeader("Project overview"),
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                spacing: 32,
+                children: [
+                  Column(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    spacing: 8,
+                    children: [
+                      LargeLabel("${loc!.projectOverview_projectName}:"),
+                      Text(projectManager.loadedProject!.projectName),
+
+                      LargeLabel("${loc.createPage_uploadPlaneImages}:"),
+                      Text(projectManager.loadedProject!.imageFolderPath),
+
+                      LargeLabel("${loc.createPage_uploadSOSIFile}:"),
+                      Text(projectManager.loadedProject!.sosiFilePath),
+
+                      LargeLabel("${loc.createPage_uploadWaterSOSIFile}:"),
+                      Text(
+                        projectManager.loadedProject?.sosiWaterMaskPath != null
+                            ? projectManager.loadedProject!.sosiWaterMaskPath!
+                            : loc.projectOverview_noWaterSosi,
+                      ),
+                    ],
+                  ),
+                  if (!_isLoading)
+                    Column(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        LargeLabel("${loc.projectOverview_imagesPresent}:"),
+                        Text(_projectInfo!.imagesInFolder.toString()),
+
+                        LargeLabel("${loc.projectOverview_imagesProcessed}:"),
+                        Text(
+                          projectManager.loadedProject!.allSets.length
+                              .toString(),
+                        ),
+
+                        LargeLabel(
+                          "${loc.projectOverview_lastImageProcessed}:",
+                        ),
+                        Text(
+                          projectManager.loadedProject!.allSets.isEmpty
+                              ? loc.g_noImagesProcessed
+                              : projectManager
+                                    .loadedProject!
+                                    .allSets[_projectInfo!.lastProcessedImage]
+                                    .imageName,
+                        ),
+                      ],
+                    ),
+                ],
+              ),
+            ),
+
+            Spacer(),
+            // Run analysis button
+            Align(
+              alignment: Alignment.centerRight,
+              child: SizedBox(
+                height: 48,
+                child: ElevatedButton(
+                  onPressed: () => _startAnomalyDetection(projectManager),
+                  child: Row(
+                    spacing: 16,
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        "Run anomaly analysis",
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
+                      Icon(
+                        Icons.arrow_forward_ios_outlined,
+                        size: 20,
+                        color: Theme.of(context).brightness == Brightness.light
+                            ? MyColors.secondaryBlack
+                            : MyColors.primaryWhite,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: BottomStatusBar(),
+    );
+  }
+}

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -98,7 +98,7 @@ class Settings extends StatelessWidget {
         ),
       ),
       appBar: TopBar(foreignContext: context),
-      bottomNavigationBar: BottomStatusBar(foreignContext: context),
+      bottomNavigationBar: BottomStatusBar(),
     );
   }
 }

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:skavl/model/settings_model.dart';
+import 'package:skavl/widgets/bottom_status_bar.dart';
 import 'package:skavl/widgets/labels/headings.dart';
 import 'package:skavl/widgets/top_bar.dart';
 
@@ -97,6 +98,7 @@ class Settings extends StatelessWidget {
         ),
       ),
       appBar: TopBar(foreignContext: context),
+      bottomNavigationBar: BottomStatusBar(foreignContext: context),
     );
   }
 }

--- a/lib/services/project_file_service.dart
+++ b/lib/services/project_file_service.dart
@@ -1,0 +1,42 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../entity/project_metadata.dart';
+
+/// Project file service class
+///
+/// Singleton for loads, saves and creating new projects to and from files.
+class ProjectFileService {
+  static final ProjectFileService _instance = ProjectFileService._internal();
+
+  factory ProjectFileService() => _instance;
+
+  ProjectFileService._internal();
+
+  /// Load project metadata from file
+  Future<ProjectMetadata> loadFromFile(String filePath) async {
+    final file = File(filePath);
+    final content = await file.readAsString();
+    final json = jsonDecode(content) as Map<String, dynamic>;
+    return ProjectMetadata.fromJson(json);
+  }
+
+  /// Save project metadata to file
+  Future<void> saveToFile(String filePath, ProjectMetadata project) async {
+    final file = File(filePath);
+    final content = const JsonEncoder.withIndent(
+      '  ',
+    ).convert(project.toJson());
+    await file.writeAsString(content);
+  }
+
+  /// Create new project file with given metadata and return the file path
+  Future<String> createNewFile(
+    String directoryPath,
+    ProjectMetadata project,
+  ) async {
+    final filePath = '$directoryPath/${project.projectName}.skavl';
+    await saveToFile(filePath, project);
+    return filePath;
+  }
+}

--- a/lib/services/project_manager_service.dart
+++ b/lib/services/project_manager_service.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/cupertino.dart';
+import 'package:skavl/entity/project_metadata.dart';
+
+/// Service that holds current project in the context
+///
+/// Used for global project metadata access.
+class ProjectManagerService extends ChangeNotifier {
+  ProjectMetadata? _loadedProject;
+  String? _filePath;
+
+  /// Get loaded project
+  ProjectMetadata? get loadedProject => _loadedProject;
+
+  /// Get project filepath
+  String? get filePath => _filePath;
+
+  /// Return if project i sloaded
+  bool get hasProject => _loadedProject != null;
+
+  /// Set project for context
+  void setProject(ProjectMetadata project, String filePath) {
+    _loadedProject = project;
+    _filePath = filePath;
+    notifyListeners();
+  }
+
+  /// Clear project for context
+  void clearProject() {
+    _loadedProject = null;
+    _filePath = null;
+    notifyListeners();
+  }
+}

--- a/lib/theme/app_themes.dart
+++ b/lib/theme/app_themes.dart
@@ -17,7 +17,7 @@ class AppThemes {
       titleSmall: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
       bodyMedium: const TextStyle(fontSize: 16),
       bodySmall: const TextStyle(fontSize: 12),
-      labelLarge: const TextStyle(fontSize: 14)
+      labelLarge: const TextStyle(fontSize: 16)
     ),
 
     // PAGE TRANSITION THEME

--- a/lib/util/project_actions.dart
+++ b/lib/util/project_actions.dart
@@ -1,6 +1,8 @@
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
+import 'package:skavl/main.dart';
+import 'package:skavl/util/navigation_util.dart';
 
 import '../services/project_file_service.dart';
 import '../services/project_manager_service.dart';
@@ -63,5 +65,16 @@ class ProjectActions {
     if (projectPath == null) return;
 
     await ProjectFileService().saveToFile(projectPath, currentProject);
+  }
+
+  /// Closes current project and navigates back to the home page
+  ///
+  /// Might have to implement some check for stopping current analysis before closing
+  static Future<void> closeProject(BuildContext context) async {
+    final projectState = context.read<ProjectManagerService>();
+    if (!projectState.hasProject) return;
+
+    projectState.clearProject();
+    navigateTo(context, MainPage());
   }
 }

--- a/lib/util/project_actions.dart
+++ b/lib/util/project_actions.dart
@@ -1,0 +1,67 @@
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:provider/provider.dart';
+
+import '../services/project_file_service.dart';
+import '../services/project_manager_service.dart';
+
+/// Class to provide static methods for saving, loading and creating projects
+///
+/// Methods here handle the "UI" part of projects such as opening file pickers etc.
+/// See [ProjectFileService] for the actual file operations.
+class ProjectActions {
+
+  /// Opens a project from file and sets the context
+  static Future<void> openProject(BuildContext context) async {
+
+    final projectState = context.read<ProjectManagerService>();
+
+    final loadedFile = await FilePicker.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['skavl'],
+    );
+    if (loadedFile == null) return;
+
+    final filepath = loadedFile.files.single.path;
+    if (filepath == null) return;
+
+    final project = await ProjectFileService().loadFromFile(filepath);
+    projectState.setProject(project, filepath);
+  }
+
+  /// Saves current project to specified file
+  static Future<void> saveAs(BuildContext context) async {
+    final projectState = context.read<ProjectManagerService>();
+    if (!projectState.hasProject) return;
+
+    final savePath = await FilePicker.saveFile(
+      dialogTitle: 'Save project',
+      fileName: '${projectState.loadedProject?.projectName}.skavl',
+      type: FileType.custom,
+      allowedExtensions: ['skavl'],
+    );
+    if (savePath == null) return;
+
+    final currentProject = projectState.loadedProject;
+    if (currentProject == null) return;
+
+    await ProjectFileService().saveToFile(savePath, currentProject);
+
+    final project = await ProjectFileService().loadFromFile(savePath);
+    projectState.setProject(project, savePath);
+  }
+
+  /// Saves current project to current file
+  static Future<void> saveProject(BuildContext context) async {
+    final projectState = context.read<ProjectManagerService>();
+    if (!projectState.hasProject) return;
+
+    final currentProject = projectState.loadedProject;
+    if (currentProject == null) return;
+
+    final projectPath = projectState.filePath;
+    if (projectPath == null) return;
+
+    await ProjectFileService().saveToFile(projectPath, currentProject);
+  }
+}

--- a/lib/widgets/bottom_status_bar.dart
+++ b/lib/widgets/bottom_status_bar.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:skavl/services/project_manager_service.dart';
+
+import '../l10n/app_localizations.dart';
+import '../theme/colors.dart';
+
+class BottomStatusBar extends StatelessWidget {
+  final BuildContext foreignContext;
+
+  const BottomStatusBar({super.key, required this.foreignContext});
+
+  AppLocalizations? loc() {
+    return AppLocalizations.of(foreignContext);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ProjectManagerService projectManagerService = context.watch<ProjectManagerService>();
+
+    // TODO: implement build
+    return Column(
+      children: [
+        Divider(height: 1, thickness: 2),
+        Container(
+          height: 24,
+          color: Theme.of(context).appBarTheme.backgroundColor,
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          alignment: Alignment.centerLeft,
+          child: Text(projectManagerService.hasProject ? "Project: ${projectManagerService.loadedProject!.projectName}" : "Project: none", style: Theme.of(context).textTheme.bodySmall),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/bottom_status_bar.dart
+++ b/lib/widgets/bottom_status_bar.dart
@@ -8,18 +8,15 @@ import '../l10n/app_localizations.dart';
 ///
 /// Only used for displaying information to the user
 class BottomStatusBar extends StatelessWidget {
-  final BuildContext foreignContext;
+  const BottomStatusBar({super.key});
 
-  const BottomStatusBar({super.key, required this.foreignContext});
 
-  AppLocalizations? loc() {
-    return AppLocalizations.of(foreignContext);
-  }
 
   @override
   Widget build(BuildContext context) {
     ProjectManagerService projectManagerService = context
         .watch<ProjectManagerService>();
+    final loc = AppLocalizations.of(context);
 
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -32,8 +29,8 @@ class BottomStatusBar extends StatelessWidget {
           alignment: Alignment.centerLeft,
           child: Text(
             projectManagerService.hasProject
-                ? "${loc()?.g_project}: ${projectManagerService.loadedProject!.projectName}"
-                : "${loc()?.g_project}: none",
+                ? "${loc!.g_project}: ${projectManagerService.loadedProject!.projectName}"
+                : "${loc!.g_project}: none",
             style: Theme.of(context).textTheme.bodySmall,
           ),
         ),

--- a/lib/widgets/bottom_status_bar.dart
+++ b/lib/widgets/bottom_status_bar.dart
@@ -4,6 +4,9 @@ import 'package:skavl/services/project_manager_service.dart';
 
 import '../l10n/app_localizations.dart';
 
+/// Status bar to show if a project is loaded in the application or not
+///
+/// Only used for displaying information to the user
 class BottomStatusBar extends StatelessWidget {
   final BuildContext foreignContext;
 
@@ -15,10 +18,11 @@ class BottomStatusBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    ProjectManagerService projectManagerService = context.watch<ProjectManagerService>();
+    ProjectManagerService projectManagerService = context
+        .watch<ProjectManagerService>();
 
-    // TODO: implement build
     return Column(
+      mainAxisSize: MainAxisSize.min,
       children: [
         Divider(height: 1, thickness: 2),
         Container(
@@ -26,7 +30,12 @@ class BottomStatusBar extends StatelessWidget {
           color: Theme.of(context).appBarTheme.backgroundColor,
           padding: const EdgeInsets.symmetric(horizontal: 8),
           alignment: Alignment.centerLeft,
-          child: Text(projectManagerService.hasProject ? "Project: ${projectManagerService.loadedProject!.projectName}" : "Project: none", style: Theme.of(context).textTheme.bodySmall),
+          child: Text(
+            projectManagerService.hasProject
+                ? "${loc()?.g_project}: ${projectManagerService.loadedProject!.projectName}"
+                : "${loc()?.g_project}: none",
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
         ),
       ],
     );

--- a/lib/widgets/bottom_status_bar.dart
+++ b/lib/widgets/bottom_status_bar.dart
@@ -1,10 +1,8 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:skavl/services/project_manager_service.dart';
 
 import '../l10n/app_localizations.dart';
-import '../theme/colors.dart';
 
 class BottomStatusBar extends StatelessWidget {
   final BuildContext foreignContext;

--- a/lib/widgets/labels/fieldlabels.dart
+++ b/lib/widgets/labels/fieldlabels.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+/// Semantic LargeHeader component to represent headers
+///
+/// Acts as wrapper for [Text] and applies [labelLarge] from ThemeData
+/// Uses Semantic labels for screen readers
+class LargeLabel extends StatelessWidget {
+  final String text;
+  final String? semanticLabel;
+  const LargeLabel(this.text, {super.key, this.semanticLabel});
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      header: false,
+      label: semanticLabel,
+      child: Text(text, style: Theme.of(context).textTheme.labelLarge),
+    );
+  }
+}
+
+/// Semantic LargeHeader component to represent headers
+/// Acts as wrapper for [Text] and applies [labelMedium] from ThemeData
+class MediumLabel extends StatelessWidget {
+  final String text;
+  final String? semanticLabel;
+  const MediumLabel(this.text, {super.key, this.semanticLabel});
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      header: false,
+      label: semanticLabel,
+      child: Text(text, style: Theme.of(context).textTheme.labelMedium),
+    );
+  }
+}
+
+/// Semantic SmallHeader component to represent headers
+/// Acts as wrapper for [Text] and applies [labelSmall] from ThemeData
+class SmallLabel extends StatelessWidget {
+  final String text;
+  final String? semanticLabel;
+  const SmallLabel(this.text, {super.key, this.semanticLabel});
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      header: false,
+      label: semanticLabel,
+      child: Text(text, style: Theme.of(context).textTheme.labelSmall),
+    );
+  }
+}

--- a/lib/widgets/long_button.dart
+++ b/lib/widgets/long_button.dart
@@ -2,9 +2,10 @@ import 'package:flutter/material.dart';
 
 
 class LongButton extends StatelessWidget {
-  const LongButton(this.title, {super.key});
+  const LongButton(this.title, {super.key, this.onPressed});
 
   final String title;
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -12,8 +13,7 @@ class LongButton extends StatelessWidget {
       width: 400,
       height: 50,
       child: ElevatedButton(
-        onPressed: () {
-        },
+        onPressed: onPressed,
         child: Text(title, 
           style: Theme.of(context).textTheme.bodyMedium),
       ),

--- a/lib/widgets/top_bar.dart
+++ b/lib/widgets/top_bar.dart
@@ -4,6 +4,7 @@ import 'package:skavl/main.dart';
 import 'package:skavl/pages/analysis.dart';
 import 'package:skavl/pages/create_new_project.dart';
 import 'package:skavl/pages/create_new_report.dart';
+import 'package:skavl/pages/project_overview.dart';
 import 'package:skavl/pages/settings.dart';
 import 'package:skavl/util/project_actions.dart';
 
@@ -79,13 +80,16 @@ class TopBar extends StatelessWidget implements PreferredSizeWidget {
                     SubmenuButton(
                       menuChildren: <Widget>[
                         menuItem(loc()!.g_home, () {
-                          navigateTo(context, MyHomePage(title: "title"));
+                          navigateTo(context, MainPage());
                         }),
                         menuItem("Upload page", () {
                           navigateTo(context, CreateNewReportPage());
                         }),
                         menuItem("Analysis page", () {
                           navigateTo(context, Analysis());
+                        }),
+                        menuItem("Project Overview page", () {
+                          navigateTo(context, ProjectOverview());
                         }),
                         PopupMenuDivider(),
                         menuItem(loc()!.g_save, () => ProjectActions.saveProject(context)),

--- a/lib/widgets/top_bar.dart
+++ b/lib/widgets/top_bar.dart
@@ -4,7 +4,6 @@ import 'package:skavl/main.dart';
 import 'package:skavl/pages/analysis.dart';
 import 'package:skavl/pages/create_new_project.dart';
 import 'package:skavl/pages/create_new_report.dart';
-import 'package:skavl/pages/project_overview.dart';
 import 'package:skavl/pages/settings.dart';
 import 'package:skavl/util/project_actions.dart';
 

--- a/lib/widgets/top_bar.dart
+++ b/lib/widgets/top_bar.dart
@@ -1,14 +1,11 @@
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:skavl/l10n/app_localizations.dart';
 import 'package:skavl/main.dart';
 import 'package:skavl/pages/analysis.dart';
 import 'package:skavl/pages/create_new_project.dart';
 import 'package:skavl/pages/create_new_report.dart';
 import 'package:skavl/pages/settings.dart';
-import 'package:skavl/services/project_file_service.dart';
-import 'package:skavl/services/project_manager_service.dart';
+import 'package:skavl/util/project_actions.dart';
 
 import '../util/navigation_util.dart';
 
@@ -61,61 +58,8 @@ class TopBar extends StatelessWidget implements PreferredSizeWidget {
     );
   }
 
-  /// Opens a project from file and sets the context
-  Future<void> _openProject(BuildContext context) async {
-
-    final projectState = context.read<ProjectManagerService>();
-
-    final loadedFile = await FilePicker.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: ['skavl'],
-    );
-    if (loadedFile == null) return;
-
-    final filepath = loadedFile.files.single.path;
-    if (filepath == null) return;
-
-    final project = await ProjectFileService().loadFromFile(filepath);
-    projectState.setProject(project, filepath);
-  }
-
-  /// Saves current project to specified file
-  Future<void> _saveAs(BuildContext context) async {
-    final projectState = context.read<ProjectManagerService>();
-    if (!projectState.hasProject) return;
-
-    final savePath = await FilePicker.saveFile(
-      dialogTitle: 'Save project',
-      fileName: '${projectState.loadedProject?.projectName}.skavl',
-      type: FileType.custom,
-      allowedExtensions: ['skavl'],
-    );
-    if (savePath == null) return;
-
-    final currentProject = projectState.loadedProject;
-    if (currentProject == null) return;
-
-    await ProjectFileService().saveToFile(savePath, currentProject);
-
-    final project = await ProjectFileService().loadFromFile(savePath);
-    projectState.setProject(project, savePath);
-  }
-  
-  Future<void> _saveProject(BuildContext context) async {
-    final projectState = context.read<ProjectManagerService>();
-    if (!projectState.hasProject) return;
-    
-    final currentProject = projectState.loadedProject;
-    if (currentProject == null) return;
-
-    final projectPath = projectState.filePath;
-    if (projectPath == null) return;
-    
-    await ProjectFileService().saveToFile(projectPath, currentProject);
-  }
-
-
   /// Builds the top bar widget, which consists of a row of menu buttons (File, Edit, View, Help).
+  ///
   /// Each menu button is a SubmenuButton that contains a list of menu items or submenus,
   /// allowing for easy navigation and access to various features of the application.
   @override
@@ -144,12 +88,12 @@ class TopBar extends StatelessWidget implements PreferredSizeWidget {
                           navigateTo(context, Analysis());
                         }),
                         PopupMenuDivider(),
-                        menuItem(loc()!.g_save, () => _saveProject(context)),
-                        menuItem(loc()!.topbar_saveAs, () => _saveAs(context)),
+                        menuItem(loc()!.g_save, () => ProjectActions.saveProject(context)),
+                        menuItem(loc()!.topbar_saveAs, () => ProjectActions.saveAs(context)),
                         menuItem(loc()!.topbar_newProject, () {
                           navigateTo(context, CreateNewProject());
                         }),
-                        menuItem(loc()!.topbar_openProject, () => _openProject(context)),
+                        menuItem(loc()!.topbar_openProject, () => ProjectActions.openProject(context)),
                         submenu(loc()!.topbar_openRecent, []),
                         submenu(loc()!.g_share, [
                           menuItem(loc()!.g_share, () {}),

--- a/lib/widgets/top_bar.dart
+++ b/lib/widgets/top_bar.dart
@@ -1,6 +1,5 @@
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:path/path.dart';
 import 'package:provider/provider.dart';
 import 'package:skavl/l10n/app_localizations.dart';
 import 'package:skavl/main.dart';

--- a/lib/widgets/top_bar.dart
+++ b/lib/widgets/top_bar.dart
@@ -1,12 +1,16 @@
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:path/path.dart';
+import 'package:provider/provider.dart';
 import 'package:skavl/l10n/app_localizations.dart';
 import 'package:skavl/main.dart';
 import 'package:skavl/pages/analysis.dart';
 import 'package:skavl/pages/create_new_report.dart';
 import 'package:skavl/pages/settings.dart';
+import 'package:skavl/services/project_file_service.dart';
+import 'package:skavl/services/project_manager_service.dart';
 
 import '../util/navigation_util.dart';
-
 
 /// A custom top bar widget that implements the PreferredSizeWidget interface,
 ///  allowing it to be used as an AppBar in a Scaffold.
@@ -15,31 +19,32 @@ import '../util/navigation_util.dart';
 class TopBar extends StatelessWidget implements PreferredSizeWidget {
   final BuildContext foreignContext;
   final double height = 25;
+
   const TopBar({super.key, required this.foreignContext});
 
   AppLocalizations? loc() {
     return AppLocalizations.of(foreignContext);
   }
 
-/// Returns a ButtonStyle for menu items, with fixed and minimum sizes based on the height property.
-/// This style ensures that all menu items have a consistent size, improving the overall appearance of the menu.
-/// The fixedSize is set to a width of 200 and a height slightly larger than the defined height, while the minimumSize
-///  ensures that menu items do not shrink below the specified dimensions.
+  /// Returns a ButtonStyle for menu items, with fixed and minimum sizes based on the height property.
+  /// This style ensures that all menu items have a consistent size, improving the overall appearance of the menu.
+  /// The fixedSize is set to a width of 200 and a height slightly larger than the defined height, while the minimumSize
+  ///  ensures that menu items do not shrink below the specified dimensions.
   ButtonStyle menuItemStyle() {
     return ButtonStyle(
-      fixedSize: WidgetStateProperty.all(Size(200, height+5)),
+      fixedSize: WidgetStateProperty.all(Size(200, height + 5)),
       minimumSize: WidgetStateProperty.all(Size(25, height)),
     );
   }
 
-/// Creates a MenuItemButton with the given text and onPressed callback.
-/// The button is styled using the menuItemStyle method to ensure consistent sizing.
-/// The text is displayed with an accelerator label, allowing for keyboard shortcuts
-///  to be easily identified by the user.
+  /// Creates a MenuItemButton with the given text and onPressed callback.
+  /// The button is styled using the menuItemStyle method to ensure consistent sizing.
+  /// The text is displayed with an accelerator label, allowing for keyboard shortcuts
+  ///  to be easily identified by the user.
   MenuItemButton menuItem(String text, void Function() onPressed) {
     return MenuItemButton(
       onPressed: onPressed,
-       style :menuItemStyle(),
+      style: menuItemStyle(),
       child: MenuAcceleratorLabel('&$text'), // child
     );
   }
@@ -50,17 +55,69 @@ class TopBar extends StatelessWidget implements PreferredSizeWidget {
   ///  to be easily identified by the user.
   SubmenuButton submenu(String text, List<Widget> children) {
     return SubmenuButton(
-      style :menuItemStyle(),
+      style: menuItemStyle(),
       menuChildren: children,
       child: MenuAcceleratorLabel('&$text'), // Parent
     );
   }
 
-  
+  /// Opens a project from file and sets the context
+  Future<void> _openProject(BuildContext context) async {
 
-/// Builds the top bar widget, which consists of a row of menu buttons (File, Edit, View, Help).
-/// Each menu button is a SubmenuButton that contains a list of menu items or submenus,
-/// allowing for easy navigation and access to various features of the application.
+    final projectState = context.read<ProjectManagerService>();
+
+    final loadedFile = await FilePicker.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['skavl'],
+    );
+    if (loadedFile == null) return;
+
+    final filepath = loadedFile.files.single.path;
+    if (filepath == null) return;
+
+    final project = await ProjectFileService().loadFromFile(filepath);
+    projectState.setProject(project, filepath);
+  }
+
+  /// Saves current project to specified file
+  Future<void> _saveAs(BuildContext context) async {
+    final projectState = context.read<ProjectManagerService>();
+    if (!projectState.hasProject) return;
+
+    final savePath = await FilePicker.saveFile(
+      dialogTitle: 'Save project',
+      fileName: '${projectState.loadedProject?.projectName}.skavl',
+      type: FileType.custom,
+      allowedExtensions: ['skavl'],
+    );
+    if (savePath == null) return;
+
+    final currentProject = projectState.loadedProject;
+    if (currentProject == null) return;
+
+    await ProjectFileService().saveToFile(savePath, currentProject);
+
+    final project = await ProjectFileService().loadFromFile(savePath);
+    projectState.setProject(project, savePath);
+  }
+  
+  Future<void> _saveProject(BuildContext context) async {
+    final projectState = context.read<ProjectManagerService>();
+    if (!projectState.hasProject) return;
+    
+    final currentProject = projectState.loadedProject;
+    if (currentProject == null) return;
+
+    final projectPath = projectState.filePath;
+    if (projectPath == null) return;
+    
+    await ProjectFileService().saveToFile(projectPath, currentProject);
+  }
+
+
+  /// Builds the top bar widget, which consists of a row of menu buttons (File, Edit, View, Help).
+  /// Each menu button is a SubmenuButton that contains a list of menu items or submenus,
+  /// allowing for easy navigation and access to various features of the application.
   @override
   Widget build(BuildContext context) {
     return Center(
@@ -77,57 +134,62 @@ class TopBar extends StatelessWidget implements PreferredSizeWidget {
                   children: <Widget>[
                     SubmenuButton(
                       menuChildren: <Widget>[
-                        menuItem(loc()!.g_home, (){
+                        menuItem(loc()!.g_home, () {
                           navigateTo(context, MyHomePage(title: "title"));
                         }),
-                        menuItem("Upload page", (){
+                        menuItem("Upload page", () {
                           navigateTo(context, CreateNewReportPage());
                         }),
-                        menuItem("Analysis page", (){
+                        menuItem("Analysis page", () {
                           navigateTo(context, Analysis());
                         }),
                         PopupMenuDivider(),
-                        menuItem(loc()!.g_save, (){}),
-                        menuItem(loc()!.topbar_saveAs, (){}),
-                        menuItem(loc()!.topbar_newProject, (){}),
-                        menuItem(loc()!.topbar_openProject, (){}),
+                        menuItem(loc()!.g_save, () => _saveProject(context)),
+                        menuItem(loc()!.topbar_saveAs, () => _saveAs(context)),
+                        menuItem(loc()!.topbar_newProject, () {}),
+                        menuItem(loc()!.topbar_openProject, () => _openProject(context)),
                         submenu(loc()!.topbar_openRecent, []),
                         submenu(loc()!.g_share, [
-                          menuItem(loc()!.g_share, (){}),
-                          ]
-                        ),
-                        menuItem(loc()!.topbar_newWindow, (){}),
-                        menuItem(loc()!.g_quit, (){}),
+                          menuItem(loc()!.g_share, () {}),
+                        ]),
+                        menuItem(loc()!.topbar_newWindow, () {}),
+                        menuItem(loc()!.g_quit, () {}),
                       ],
-                      child:  MenuAcceleratorLabel('&${loc()!.g_file}'), // Parent
+                      child: MenuAcceleratorLabel(
+                        '&${loc()!.g_file}',
+                      ), // Parent
                     ),
                     SubmenuButton(
                       menuChildren: <Widget>[
-                        menuItem(loc()!.g_settings, (){
+                        menuItem(loc()!.g_settings, () {
                           navigateTo(context, Settings());
                         }),
                       ],
-                      child:  MenuAcceleratorLabel('&${loc()!.g_edit}'), // Parent
+                      child: MenuAcceleratorLabel(
+                        '&${loc()!.g_edit}',
+                      ), // Parent
+                    ),
+                    SubmenuButton(
+                      menuChildren: <Widget>[],
+                      child: MenuAcceleratorLabel(
+                        '&${loc()!.g_view}',
+                      ), // Parent
                     ),
                     SubmenuButton(
                       menuChildren: <Widget>[
-                       
+                        menuItem(loc()!.topbar_about, () {
+                          showAboutDialog(
+                            context: foreignContext,
+                            applicationName: 'Skavl',
+                            applicationVersion: '0.1.0',
+                            applicationLegalese: '© 2026 Bouvetøya AS',
+                          );
+                        }),
                       ],
-                      child:  MenuAcceleratorLabel('&${loc()!.g_view}'), // Parent
+                      child: MenuAcceleratorLabel(
+                        '&${loc()!.g_help}',
+                      ), // Parent
                     ),
-                    SubmenuButton(
-                      menuChildren: <Widget>[
-                       menuItem(loc()!.topbar_about, (){
-                         showAboutDialog(
-                                context: foreignContext,
-                                applicationName: 'Skavl',
-                                applicationVersion: '0.1.0',
-                                applicationLegalese: '© 2026 Bouvetøya AS',
-                              );
-                       }),
-                      ],
-                      child:  MenuAcceleratorLabel('&${loc()!.g_help}'), // Parent
-                    ), 
                   ],
                 ),
               ),
@@ -138,11 +200,7 @@ class TopBar extends StatelessWidget implements PreferredSizeWidget {
     );
   }
 
-
-
   @override
   Size get preferredSize =>
       Size(MediaQuery.of(foreignContext).size.width, height);
 }
-
-

--- a/lib/widgets/top_bar.dart
+++ b/lib/widgets/top_bar.dart
@@ -88,9 +88,6 @@ class TopBar extends StatelessWidget implements PreferredSizeWidget {
                         menuItem("Analysis page", () {
                           navigateTo(context, Analysis());
                         }),
-                        menuItem("Project Overview page", () {
-                          navigateTo(context, ProjectOverview());
-                        }),
                         PopupMenuDivider(),
                         menuItem(loc()!.g_save, () => ProjectActions.saveProject(context)),
                         menuItem(loc()!.topbar_saveAs, () => ProjectActions.saveAs(context)),
@@ -102,7 +99,7 @@ class TopBar extends StatelessWidget implements PreferredSizeWidget {
                         submenu(loc()!.g_share, [
                           menuItem(loc()!.g_share, () {}),
                         ]),
-                        menuItem(loc()!.topbar_newWindow, () {}),
+                        menuItem("${loc()!.g_close} ${loc()!.g_project}", () => ProjectActions.closeProject(context)),
                         menuItem(loc()!.g_quit, () {}),
                       ],
                       child: MenuAcceleratorLabel(

--- a/lib/widgets/top_bar.dart
+++ b/lib/widgets/top_bar.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:skavl/l10n/app_localizations.dart';
 import 'package:skavl/main.dart';
 import 'package:skavl/pages/analysis.dart';
+import 'package:skavl/pages/create_new_project.dart';
 import 'package:skavl/pages/create_new_report.dart';
 import 'package:skavl/pages/settings.dart';
 import 'package:skavl/services/project_file_service.dart';
@@ -146,7 +147,9 @@ class TopBar extends StatelessWidget implements PreferredSizeWidget {
                         PopupMenuDivider(),
                         menuItem(loc()!.g_save, () => _saveProject(context)),
                         menuItem(loc()!.topbar_saveAs, () => _saveAs(context)),
-                        menuItem(loc()!.topbar_newProject, () {}),
+                        menuItem(loc()!.topbar_newProject, () {
+                          navigateTo(context, CreateNewProject());
+                        }),
                         menuItem(loc()!.topbar_openProject, () => _openProject(context)),
                         submenu(loc()!.topbar_openRecent, []),
                         submenu(loc()!.g_share, [

--- a/lib/widgets/upload_button.dart
+++ b/lib/widgets/upload_button.dart
@@ -1,17 +1,84 @@
-import 'package:flutter/cupertino.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:skavl/widgets/labels/fieldlabels.dart';
 import 'package:skavl/widgets/upload.dart';
+
+import '../l10n/app_localizations.dart';
 
 /// Widget to select a file or folder location for use in the application
 ///
 /// Replaces [UploadBox]
 class UploadButton extends StatelessWidget {
-  const UploadButton({super.key});
+  const UploadButton({
+    super.key,
+    required this.label,
+    this.isRequired = false,
+    this.isFolder = false,
+    this.selectedPath,
+    required this.onPathSelected,
+  });
 
+  final String label;
+  final bool isRequired;
+  final bool isFolder;
+  final String? selectedPath;
+  final ValueChanged<String> onPathSelected;
+
+
+  Future<void> _pickPath(BuildContext context) async {
+    String? result;
+
+    if (isFolder) {
+      result = await FilePicker.getDirectoryPath();
+    } else {
+      final pickedFile = await FilePicker.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: ["sos"],
+      );
+      if (pickedFile != null) {
+        result = pickedFile.files.single.path;
+      }
+    }
+
+    if (result != null) {
+      onPathSelected(result);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    // TODO: implement build
-    throw UnimplementedError();
-  }
+    final loc = AppLocalizations.of(context);
 
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: 10.0,
+        children: [
+          Row(
+            spacing: 8.0,
+            children: [
+              LargeLabel(label),
+              if (isRequired) Text("*", style: TextStyle(color: Colors.red)),
+            ],
+          ),
+          Row(
+            spacing: 10.0,
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: [
+              ElevatedButton(
+                onPressed: () => _pickPath(context),
+                child: Text(loc!.g_browse),
+              ),
+              if (isFolder)
+                Text(selectedPath != null ? selectedPath! : loc.createPage_noFolder)
+              else
+                Text(selectedPath != null ? selectedPath! : loc.createPage_noFile)
+            ],
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/lib/widgets/upload_button.dart
+++ b/lib/widgets/upload_button.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/cupertino.dart';
+import 'package:skavl/widgets/upload.dart';
+
+/// Widget to select a file or folder location for use in the application
+///
+/// Replaces [UploadBox]
+class UploadButton extends StatelessWidget {
+  const UploadButton({super.key});
+
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: implement build
+    throw UnimplementedError();
+  }
+
+}


### PR DESCRIPTION
Added file based project management. Flutter handles saving and loading a project from .skavl files (json but with specific file extension for our software).

Refactored homepage to only display if a project is not loaded. If a project is loaded, the homepage becomes a project overview page. To get back to the "home page", the project needs to be closed from the File menu. This may change in the future, but for now it works quite decently.
Entire pipeline from starting a project, starting an anomaly and then analyzing images is not finished yet and will need to continue once AnomalySet is implemented fully on the python side.

Related issue #109  