### PR TITLE
Feat ports implementation

### DIFF
--- a/lib/entity/service_port_config.dart
+++ b/lib/entity/service_port_config.dart
@@ -1,31 +1,41 @@
-
-/// Entity for setting ports, connection ips and service names.
-///
-/// Used mostly for organizational purposes.
+/// Entity for setting service ports, connection ips and service names.
 class ServicePortConfig {
-  String _name = "default_service";
-  String _ip = "127.0.0.1";
-  String _port = "50051";
+  final String name;
+  final String ip;
+  final int port;
 
+  /// Default constructor for the ServicePortConfig
+  const ServicePortConfig({
+    this.name = "default_service",
+    this.ip = "127.0.0.1",
+    this.port = 50051,
+  });
 
-
-  String get name => _name;
-  String get ip => _ip;
-  String get port => _port;
-
-  /// Sets the name for the service
-  void setName(String name) {
-    _name = name;
+  /// Deserialize from Json
+  factory ServicePortConfig.fromJson(Map<String, dynamic> json) {
+    return ServicePortConfig(
+      name: json['name'] as String,
+      ip: json['ip'] as String,
+      port: json['port'] as int,
+    );
   }
 
-  /// Sets the connection IP for the service
-  void setIp(String ip) {
-    _ip = ip;
-  }
+  /// Serialize to Json
+  Map<String, dynamic> toJson() => {'name': name, 'ip': ip, 'port': port};
 
-  /// Sets the port to connect to for the service
-  void setPort(String port) {
-    _port = port;
+  /// Creates a new instance if only one or more fields are updated.
+  ServicePortConfig copyWith({
+    String? name,
+    String? ip,
+    int? port,
+  }) {
+    return ServicePortConfig(
+      name: name ?? this.name,
+      ip: ip ?? this.ip,
+      port: port ?? this.port,
+    );
   }
 
 }
+
+

--- a/lib/entity/service_port_config.dart
+++ b/lib/entity/service_port_config.dart
@@ -1,0 +1,31 @@
+
+/// Entity for setting ports, connection ips and service names.
+///
+/// Used mostly for organizational purposes.
+class ServicePortConfig {
+  String _name = "default_service";
+  String _ip = "127.0.0.1";
+  String _port = "50051";
+
+
+
+  String get name => _name;
+  String get ip => _ip;
+  String get port => _port;
+
+  /// Sets the name for the service
+  void setName(String name) {
+    _name = name;
+  }
+
+  /// Sets the connection IP for the service
+  void setIp(String ip) {
+    _ip = ip;
+  }
+
+  /// Sets the port to connect to for the service
+  void setPort(String port) {
+    _port = port;
+  }
+
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -128,11 +128,14 @@ class _MainPageState extends State<MainPage> {
   Future<void> _initServices() async {
     await PortConfigService().initialize();
 
-    if (!await NetworkUtil.isPortInUse(50051)) {
-      _tilerService.start(args: ["--port","50051","--local"]);
+    final tilerConfig = PortConfigService().getConfig("skavl_tiler");
+    if (!await NetworkUtil.isPortInUse(tilerConfig.port)) {
+      _tilerService.start(args: ["--port",tilerConfig.port.toString(),"--local"]);
     }
-    if (!await NetworkUtil.isPortInUse(50052)) {
-      _anomalyService.start(args: ["server", "--port", "50052","--local"]);
+
+    final anomalyConfig = PortConfigService().getConfig("skavl_anomaly");
+    if (!await NetworkUtil.isPortInUse(anomalyConfig.port)) {
+      _anomalyService.start(args: ["server", "--port", anomalyConfig.toString(),"--local"]);
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:skavl/model/settings_model.dart';
 import 'package:skavl/pages/create_new_project.dart';
 import 'package:skavl/pages/project_overview.dart';
 import 'package:skavl/services/anomaly_service_provider.dart';
+import 'package:skavl/services/port_config_service.dart';
 import 'package:skavl/services/project_manager_service.dart';
 import 'package:skavl/services/service_manager.dart';
 import 'package:skavl/theme/app_themes.dart';
@@ -120,16 +121,18 @@ class _MainPageState extends State<MainPage> {
     _initServices();
   }
 
-  /// Starts tiler and anomaly service
+  /// Checks port configs and starts submodules.
   ///
   /// Checks if ports are in use, if they are it means a zombie process or standalone server is running.
   /// Skips starting the service if port is in use as code will hook into already running instance.
   Future<void> _initServices() async {
+    await PortConfigService().initialize();
+
     if (!await NetworkUtil.isPortInUse(50051)) {
-      _tilerService.start();
+      _tilerService.start(args: ["--port","50051","--local"]);
     }
     if (!await NetworkUtil.isPortInUse(50052)) {
-      _anomalyService.start(args: ["server", "--port", "50052"]);
+      _anomalyService.start(args: ["server", "--port", "50052","--local"]);
     }
   }
 

--- a/lib/services/anomaly_service_provider.dart
+++ b/lib/services/anomaly_service_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:grpc/grpc.dart';
 import 'package:skavl/controller/anomaly_detector_controller.dart';
+import 'package:skavl/services/port_config_service.dart';
 
 import '../proto/anomaly.pbgrpc.dart';
 
@@ -22,8 +23,9 @@ class AnomalyServiceProvider extends ChangeNotifier {
     );
   }
 
-  static const String _host = "127.0.0.1";
-  static const int _port = 50052;
+  final anomalyConfig = PortConfigService().getConfig("skavl_anomaly");
+  late final String _host = anomalyConfig.ip;
+  late final int _port = anomalyConfig.port;
 
   late final ClientChannel _channel;
   late final AnomalyDetectorController controller;

--- a/lib/services/port_config_service.dart
+++ b/lib/services/port_config_service.dart
@@ -1,0 +1,90 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:path/path.dart' as path;
+import '../entity/service_port_config.dart';
+
+/// Service for managing port configurations.
+class PortConfigService {
+  static final PortConfigService _instance = PortConfigService._internal();
+
+  factory PortConfigService() => _instance;
+
+  PortConfigService._internal();
+
+  late List<ServicePortConfig> _configs;
+
+  List<ServicePortConfig> get configs => List.unmodifiable(_configs);
+
+  /// Service default values
+  static const List<ServicePortConfig> _defaults = [
+    ServicePortConfig(name: 'tiler', ip: '127.0.0.1', port: 50021),
+    ServicePortConfig(name: 'anomaly_detection', ip: '127.0.0.1', port: 50022),
+    ServicePortConfig(name: 'report_generation', ip: '127.0.0.1', port: 50023),
+  ];
+
+  /// Gets normalized filepath to where the process is running
+  String get _filePath {
+    final appDir = File(Platform.resolvedExecutable).parent.path;
+    return path.normalize(path.join(appDir, 'ports.json'));
+  }
+
+  /// Loads [ServicePortConfig] configurations from file.
+  Future<List<ServicePortConfig>> _loadFromFile() async {
+    final file = File(_filePath);
+    final content = await file.readAsString();
+    final jsonList = jsonDecode(content) as List<dynamic>;
+    return jsonList
+        .map((e) => ServicePortConfig.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Saves current [ServicePortConfig] configurations to file.
+  Future<void> _saveToFile() async {
+    final content = const JsonEncoder.withIndent(
+      '  ',
+    ).convert(_configs.map((c) => c.toJson()).toList());
+    await File(_filePath).writeAsString(content);
+  }
+
+  /// Initializes the [ServicePortConfig] by loading from ports.json or creating defaults.
+  ///
+  /// If the file does not exist, writes defaults.
+  /// If the file exists but is missing entries, appends the missing defaults.
+  Future<void> initialize() async {
+    final file = File(_filePath);
+    if (!await file.exists()) {
+      _configs = List.from(_defaults);
+      await _saveToFile();
+      return;
+    }
+
+    _configs = await _loadFromFile();
+    bool modified = false;
+    for (final defaultConfig in _defaults) {
+      if (!_configs.any((c) => c.name == defaultConfig.name)) {
+        _configs.add(defaultConfig);
+        modified = true;
+      }
+    }
+
+    if (modified) {
+      await _saveToFile();
+    }
+  }
+
+  /// Updates a [ServicePortConfig] by name and saves to file.
+  Future<void> updateConfig(String name, ServicePortConfig updated) async {
+    final index = _configs.indexWhere((c) => c.name == name);
+    _configs[index] = updated;
+    await _saveToFile();
+  }
+
+  /// Returns the [ServicePortConfig] for a given service name, or null if not found.
+  ServicePortConfig? getConfig(String name) {
+    try {
+      return _configs.firstWhere((c) => c.name == name);
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/services/port_config_service.dart
+++ b/lib/services/port_config_service.dart
@@ -17,9 +17,9 @@ class PortConfigService {
 
   /// Service default values
   static const List<ServicePortConfig> _defaults = [
-    ServicePortConfig(name: 'tiler', ip: '127.0.0.1', port: 50021),
-    ServicePortConfig(name: 'anomaly_detection', ip: '127.0.0.1', port: 50022),
-    ServicePortConfig(name: 'report_generation', ip: '127.0.0.1', port: 50023),
+    ServicePortConfig(name: 'skavl_tiler', ip: '127.0.0.1', port: 50021),
+    ServicePortConfig(name: 'skavl_anomaly', ip: '127.0.0.1', port: 50022),
+    ServicePortConfig(name: 'skavl_report', ip: '127.0.0.1', port: 50023),
   ];
 
   /// Gets normalized filepath to where the process is running
@@ -80,11 +80,7 @@ class PortConfigService {
   }
 
   /// Returns the [ServicePortConfig] for a given service name, or null if not found.
-  ServicePortConfig? getConfig(String name) {
-    try {
-      return _configs.firstWhere((c) => c.name == name);
-    } catch (_) {
-      return null;
-    }
+  ServicePortConfig getConfig(String name) {
+    return _configs.firstWhere((c) => c.name == name);
   }
 }

--- a/lib/widgets/analysis/base_analysis_view.dart
+++ b/lib/widgets/analysis/base_analysis_view.dart
@@ -9,6 +9,7 @@ import 'package:path/path.dart' as path;
 import 'package:skavl/controller/tile_scene_controller.dart';
 import 'package:skavl/entity/project_metadata.dart';
 import 'package:skavl/proto/tiler.pbgrpc.dart';
+import 'package:skavl/services/port_config_service.dart';
 import 'package:skavl/services/project_manager_service.dart';
 import 'package:skavl/util/viewport_math.dart';
 import 'package:skavl/widgets/tiler/tile_layer.dart';
@@ -95,9 +96,11 @@ abstract class BaseTileViewState<T extends BaseAnalysisView> extends State<T> {
 
     tc = TransformationController();
 
+    final tilerConfig = PortConfigService().getConfig("skavl_tiler");
+    print("Tiler config: ${tilerConfig.ip}:${tilerConfig.port}");
     channel = ClientChannel(
-      '127.0.0.1',
-      port: 50051,
+      tilerConfig.ip,
+      port: tilerConfig.port,
       options: const ChannelOptions(credentials: ChannelCredentials.insecure()),
     );
 

--- a/lib/widgets/analysis/base_analysis_view.dart
+++ b/lib/widgets/analysis/base_analysis_view.dart
@@ -97,7 +97,6 @@ abstract class BaseTileViewState<T extends BaseAnalysisView> extends State<T> {
     tc = TransformationController();
 
     final tilerConfig = PortConfigService().getConfig("skavl_tiler");
-    print("Tiler config: ${tilerConfig.ip}:${tilerConfig.port}");
     channel = ClientChannel(
       tilerConfig.ip,
       port: tilerConfig.port,

--- a/service-versions.json
+++ b/service-versions.json
@@ -1,4 +1,4 @@
 {
-  "tiler": "v0.1.2",
-  "skavl_anomaly": "v0.3.0"
+  "tiler": "v0.2.0-pre",
+  "skavl_anomaly": "v0.3.1-pre"
 }


### PR DESCRIPTION
Ports implementation using entities and a service.

Does not have a settings page or anything like that, but will take ports and connection ip from the ports.json file at the root of the project. If a file does not exist, one will be created with default values when the application initially runs. If the file exists, but a service is missing that exists in the defaults set in the service manager, it will append that service to the ports.json file with default values.