### PR TITLE
132 feat implement start from previous startmode

### DIFF
--- a/lib/controller/anomaly_detector_controller.dart
+++ b/lib/controller/anomaly_detector_controller.dart
@@ -33,13 +33,12 @@ class AnomalyDetectorController {
   );
 
   /// Sends a start procedure to the anomaly service with supplied data.
-  ///
-  /// Currently does not use information for anything, but response has been tested with print so it is ready for implementation.
   Future<DetectAnomalySetResponse> runAnalysis({
     required String imagePath,
     required String sosiPath,
     required String projectName,
     String? waterSosiPath = "",
+    StartMode startMode = StartMode.START_CONTINUE,
   }) async {
     final metadata = ProjectMetadata()
       ..projectName = projectName
@@ -53,7 +52,7 @@ class AnomalyDetectorController {
     return await anomalyDetectorClient.detectAnomalySet(
       DetectAnomalySetRequest(
         projectMetadata: metadata,
-        startMode: StartMode.START_CONTINUE,
+        startMode: startMode,
       ),
     );
   }

--- a/lib/controller/anomaly_detector_controller.dart
+++ b/lib/controller/anomaly_detector_controller.dart
@@ -53,7 +53,7 @@ class AnomalyDetectorController {
     return await anomalyDetectorClient.detectAnomalySet(
       DetectAnomalySetRequest(
         projectMetadata: metadata,
-        startMode: StartMode.START_RESTART,
+        startMode: StartMode.START_CONTINUE,
       ),
     );
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -347,8 +347,13 @@
     "description": "Title for restarting analysis popup"
   },
 
-  "projectOverview_scratchDesc": "This will delete all existing analysis results for this project and start over from the first image.\nAre you sure you want restart the analysis?",
+  "projectOverview_scratchDesc": "This will delete all existing analysis results for this project and start over from the first image.",
   "@projectOverview_scratchDesc": {
+    "description": "Description for restarting analysis popup"
+  },
+
+  "projectOverview_scratchAreyousure": "Are you sure you want restart the analysis?",
+  "@projectOverview_scratchAreyousure": {
     "description": "Description for restarting analysis popup"
   },
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -80,6 +80,7 @@
     "description": "Project"
   },
 
+
   "g_noImagesProcessed": "No images processed",
   "@g_noImagesProcessed": {
     "description": "No images processed - text when no images have been processed yet"
@@ -339,6 +340,21 @@
   "projectOverview_classified": "Generate classified report",
   "@projectOverview_classified": {
     "description": "Button for generating classified report"
+  },
+
+  "projectOverview_startFromScratch": "Restart analysis from scratch",
+  "@projectOverview_startFromScratch": {
+    "description": "Title for restarting analysis popup"
+  },
+
+  "projectOverview_scratchDesc": "This will delete all existing analysis results for this project and start over from the first image.\nAre you sure you want restart the analysis?",
+  "@projectOverview_scratchDesc": {
+    "description": "Description for restarting analysis popup"
+  },
+
+  "projectOverview_scratchConfirm": "Restart Analysis",
+  "@projectOverview_scratchConfirm":{
+    "description": "Confirm button for restarting analysis popup"
   }
 
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -53,7 +53,7 @@
 
   "g_systemLoc": "Systemspråk",
   "@g_systemLoc": {},
-  
+
   "g_enloc": "Engelsk",
   "@g_enloc": {},
 
@@ -102,12 +102,12 @@
 
   "settings_systemMode": "System modus",
   "@settings_systemMode": {},
-  
+
   "topbar_about" : "Om",
   "@topbar_about": {
     "description": "About menu item"
   },
-  
+
   "topbar_saveAs": "Lagre som",
   "@topbar_saveAs": {
     "description": "Save something as something specific"
@@ -127,7 +127,7 @@
   "@topbar_openProject": {
     "description": "Open File menu item"
   },
-  
+
   "topbar_openRecent": "Åpne nylige prosjekt",
   "@topbar_openRecent": {
     "description": "Open Recent menu item"
@@ -137,7 +137,7 @@
   "@anomalyClassifBar_confirm": {
     "description": "Bekreft avvik"
   },
-  
+
   "welcomePage_SKAVL": "Velkommen til SKAVL!",
   "@welcomePage_SKAVL": {
     "description": "Velkommen til SKAVL - title"
@@ -257,7 +257,7 @@
   "@anomalyClassifBar_anomalyType": {
     "description": "Avvik type - title"
   },
-  
+
   "anomalyClassifBar_searchCreate": "Søk eller opprett avvikstype",
   "@anomalyClassifBar_searchCreate": {
     "description": "Søk eller opprett avvikstype - text input hint"
@@ -340,6 +340,21 @@
   "projectOverview_classified": "Generer klassifisert rapport",
   "@projectOverview_classified": {
     "description": "Button for generating classified report"
+  },
+
+  "projectOverview_startFromScratch": "Start analyse fra starten",
+  "@projectOverview_startFromScratch": {
+    "description": "Title for restarting analysis popup"
+  },
+
+  "projectOverview_scratchDesc": "Dette vil slette alle eksisterende analyser for dette prosjektet og starte analyser fra første bilde.\nEr du sikker på at du vil starte analysen på nytt?",
+  "@projectOverview_scratchDesc": {
+    "description": "Description for restarting analysis popup"
+  },
+
+  "projectOverview_scratchConfirm": "Start på nytt",
+  "@projectOverview_scratchConfirm":{
+    "description": "Confirm button for restarting analysis popup"
   }
 
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -347,8 +347,13 @@
     "description": "Title for restarting analysis popup"
   },
 
-  "projectOverview_scratchDesc": "Dette vil slette alle eksisterende analyser for dette prosjektet og starte analyser fra første bilde.\nEr du sikker på at du vil starte analysen på nytt?",
+  "projectOverview_scratchDesc": "Dette vil slette alle eksisterende analyser for dette prosjektet og starte analyser fra første bilde.",
   "@projectOverview_scratchDesc": {
+    "description": "Description for restarting analysis popup"
+  },
+
+  "projectOverview_scratchAreyousure": "Er du sikker på at du vil starte analysen på nytt?",
+  "@projectOverview_scratchAreyousure": {
     "description": "Description for restarting analysis popup"
   },
 

--- a/lib/pages/project_overview.dart
+++ b/lib/pages/project_overview.dart
@@ -5,6 +5,7 @@ import 'package:skavl/entity/anomaly_def.dart';
 import 'package:skavl/pages/analysis.dart';
 import 'package:skavl/services/project_file_service.dart';
 import 'package:skavl/services/project_manager_service.dart';
+import 'package:skavl/util/anomaly_helpers.dart';
 import 'package:skavl/util/navigation_util.dart';
 import 'package:skavl/widgets/bottom_status_bar.dart';
 import 'package:skavl/widgets/dialogs/loading_popup.dart';
@@ -73,7 +74,12 @@ class _ProjectOverviewState extends State<ProjectOverview> {
               )
               .toList();
 
-          final updated = projectManager.loadedProject!.copyWith(allSets: sets);
+          final merged = mergeAnomalySets(
+            projectManager.loadedProject!.allSets,
+            sets,
+          );
+
+          final updated = projectManager.loadedProject!.copyWith(allSets: merged);
           projectManager.setProject(updated, projectManager.filePath!);
           ProjectFileService().saveToFile(projectManager.filePath!, updated);
         });

--- a/lib/pages/project_overview.dart
+++ b/lib/pages/project_overview.dart
@@ -7,6 +7,7 @@ import 'package:skavl/entity/anomaly_set.dart';
 import 'package:skavl/l10n/app_localizations.dart';
 import 'package:skavl/pages/analysis.dart';
 import 'package:skavl/proto/anomaly.pb.dart' as proto;
+import 'package:skavl/proto/anomaly.pbenum.dart';
 import 'package:skavl/services/anomaly_service_provider.dart';
 import 'package:skavl/services/project_file_service.dart';
 import 'package:skavl/services/project_manager_service.dart';
@@ -29,9 +30,11 @@ class _ProjectOverviewState extends State<ProjectOverview> {
   proto.DescribeAnomalyProjectResponse? _projectInfo;
   bool _isLoading = true;
 
-  /// Run entire analysis from data and parses it to project file.
+  /// Run entire analysis from data based on [ProjectManagerService] and [StartMode].
   ///
-  /// Will need to do incremental writes eventually to allow partial project completion.
+  /// Supports two start modes:
+  /// - Start from scratch (START_RESTART)
+  /// - Continue previous analysis as stored in the Anomaly Service database (START_CONTINUE).
   Future<void> _startAnomalyDetection(
     ProjectManagerService projectManager, {
     proto.StartMode startMode = proto.StartMode.START_CONTINUE,

--- a/lib/pages/project_overview.dart
+++ b/lib/pages/project_overview.dart
@@ -1,21 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:skavl/controller/report_generation_controller.dart';
+import 'package:skavl/entity/analysis_progress.dart';
 import 'package:skavl/entity/anomaly_def.dart';
+import 'package:skavl/entity/anomaly_set.dart';
+import 'package:skavl/l10n/app_localizations.dart';
 import 'package:skavl/pages/analysis.dart';
+import 'package:skavl/proto/anomaly.pb.dart' as proto;
+import 'package:skavl/services/anomaly_service_provider.dart';
 import 'package:skavl/services/project_file_service.dart';
 import 'package:skavl/services/project_manager_service.dart';
+import 'package:skavl/theme/colors.dart';
 import 'package:skavl/util/anomaly_helpers.dart';
 import 'package:skavl/util/navigation_util.dart';
 import 'package:skavl/widgets/bottom_status_bar.dart';
 import 'package:skavl/widgets/dialogs/loading_popup.dart';
 import 'package:skavl/widgets/labels/headings.dart';
-import 'package:skavl/entity/analysis_progress.dart';
-import 'package:skavl/entity/anomaly_set.dart';
-import 'package:skavl/l10n/app_localizations.dart';
-import 'package:skavl/proto/anomaly.pb.dart' as proto;
-import 'package:skavl/services/anomaly_service_provider.dart';
-import 'package:skavl/theme/colors.dart';
 import 'package:skavl/widgets/top_bar.dart';
 
 class ProjectOverview extends StatefulWidget {
@@ -33,8 +33,9 @@ class _ProjectOverviewState extends State<ProjectOverview> {
   ///
   /// Will need to do incremental writes eventually to allow partial project completion.
   Future<void> _startAnomalyDetection(
-    ProjectManagerService projectManager,
-  ) async {
+    ProjectManagerService projectManager, {
+    proto.StartMode startMode = proto.StartMode.START_CONTINUE,
+  }) async {
     final imagePath = projectManager.loadedProject!.imageFolderPath;
     final sosiPath = projectManager.loadedProject!.sosiFilePath;
 
@@ -58,10 +59,12 @@ class _ProjectOverviewState extends State<ProjectOverview> {
           imagePath: imagePath,
           sosiPath: sosiPath,
           waterSosiPath: projectManager.loadedProject!.sosiWaterMaskPath,
+          startMode: startMode,
         )
         .then((response) {
           controller.stopPolling();
           navigator.pop();
+
           final sets = response.anomalyResponse.anomalySets
               .map(
                 (s) => AnomalySet(
@@ -74,15 +77,74 @@ class _ProjectOverviewState extends State<ProjectOverview> {
               )
               .toList();
 
-          final merged = mergeAnomalySets(
-            projectManager.loadedProject!.allSets,
-            sets,
-          );
+          List<AnomalySet> newSets;
+          if (startMode == proto.StartMode.START_RESTART) {
+            newSets = sets;
+          } else {
+            newSets = mergeAnomalySets(
+              projectManager.loadedProject!.allSets,
+              sets,
+            );
+          }
 
-          final updated = projectManager.loadedProject!.copyWith(allSets: merged);
+          final updated = projectManager.loadedProject!.copyWith(
+            allSets: newSets,
+            currentPage: 0
+          );
           projectManager.setProject(updated, projectManager.filePath!);
           ProjectFileService().saveToFile(projectManager.filePath!, updated);
         });
+  }
+
+  /// Dialog for starting analysis from scratch.
+  ///
+  /// Hidden under 3-dot menu on project overview page.
+  Future<void> _confirmAndRestartAnalysis(
+    ProjectManagerService projectManager,
+  ) async {
+    final loc = AppLocalizations.of(context);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: MediumHeader(loc!.projectOverview_startFromScratch),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(5)),
+        content: Text(
+          loc.projectOverview_scratchDesc, textAlign: TextAlign.center,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            style: TextButton.styleFrom(
+              foregroundColor: MyColors.secondaryBlack,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(5),
+              ),
+            ),
+            child: Text(loc.g_cancel, style: Theme.of(ctx).textTheme.titleSmall),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.red.shade700,
+              foregroundColor: MyColors.primaryWhite,
+            ),
+            child: Text(
+              loc.projectOverview_scratchConfirm,
+              style: Theme.of(
+                ctx,
+              ).textTheme.titleSmall?.copyWith(color: MyColors.primaryWhite),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true && mounted) {
+      _startAnomalyDetection(
+        projectManager,
+        startMode: proto.StartMode.START_RESTART,
+      );
+    }
   }
 
   Future<void> _loadProjectInfo() async {
@@ -147,7 +209,28 @@ class _ProjectOverviewState extends State<ProjectOverview> {
           mainAxisAlignment: MainAxisAlignment.start,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            LargeHeader(loc.projectOverview_title),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                LargeHeader(loc.projectOverview_title),
+                PopupMenuButton<String>(
+                  popUpAnimationStyle: AnimationStyle.noAnimation,
+                  icon: const Icon(Icons.more_vert),
+                  onSelected: (v) {
+                    if (v == "restart") {
+                      _confirmAndRestartAnalysis(projectManager);
+                    }
+                  },
+                  itemBuilder: (ctx) => [
+                    PopupMenuItem(
+                      value: "restart",
+                      child: Text("Start analysis from scratch"),
+                    ),
+                  ],
+                ),
+              ],
+            ),
             const SizedBox(height: 24),
 
             _SectionCard(
@@ -223,25 +306,21 @@ class _ProjectOverviewState extends State<ProjectOverview> {
                 Row(
                   mainAxisAlignment: MainAxisAlignment.start,
                   children: [
-
                     SizedBox(
                       height: 48,
                       child: ElevatedButton(
-                        onPressed: projectManager
-                            .loadedProject!
-                            .unclassifiedAnomaliesInRange
-                            .isEmpty
+                        onPressed:
+                            projectManager
+                                .loadedProject!
+                                .unclassifiedAnomaliesInRange
+                                .isEmpty
                             ? null
                             : () => _generateReport(),
                         child: Row(
                           spacing: 16,
                           mainAxisAlignment: MainAxisAlignment.end,
                           mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text(
-                              loc.projectOverview_unclassified
-                            ),
-                          ],
+                          children: [Text(loc.projectOverview_unclassified)],
                         ),
                       ),
                     ),
@@ -252,21 +331,17 @@ class _ProjectOverviewState extends State<ProjectOverview> {
                       height: 48,
                       child: ElevatedButton(
                         onPressed:
-                        projectManager
-                            .loadedProject!
-                            .classifiedAnomaliesInRange
-                            .isEmpty
+                            projectManager
+                                .loadedProject!
+                                .classifiedAnomaliesInRange
+                                .isEmpty
                             ? null
                             : () => _generateReportClassified(),
                         child: Row(
                           spacing: 16,
                           mainAxisAlignment: MainAxisAlignment.end,
                           mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text(
-                              loc.projectOverview_classified
-                            ),
-                          ],
+                          children: [Text(loc.projectOverview_classified)],
                         ),
                       ),
                     ),
@@ -285,11 +360,7 @@ class _ProjectOverviewState extends State<ProjectOverview> {
                           spacing: 16,
                           mainAxisAlignment: MainAxisAlignment.end,
                           mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text(
-                              loc.projectOverview_runAnalysis,
-                            ),
-                          ],
+                          children: [Text(loc.projectOverview_runAnalysis)],
                         ),
                       ),
                     ),
@@ -306,14 +377,13 @@ class _ProjectOverviewState extends State<ProjectOverview> {
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: [
-                            Text(
-                              loc.projectOverview_classifyImages,
-                            ),
+                            Text(loc.projectOverview_classifyImages),
                             Icon(
                               Icons.arrow_forward_ios_outlined,
                               size: 20,
                               color:
-                                  Theme.of(context).brightness == Brightness.light
+                                  Theme.of(context).brightness ==
+                                      Brightness.light
                                   ? MyColors.secondaryBlack
                                   : MyColors.primaryWhite,
                             ),

--- a/lib/pages/project_overview.dart
+++ b/lib/pages/project_overview.dart
@@ -111,8 +111,16 @@ class _ProjectOverviewState extends State<ProjectOverview> {
       builder: (ctx) => AlertDialog(
         title: MediumHeader(loc!.projectOverview_startFromScratch),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(5)),
-        content: Text(
-          loc.projectOverview_scratchDesc, textAlign: TextAlign.center,
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              loc.projectOverview_scratchDesc,
+            ),
+            Text(loc.projectOverview_scratchAreyousure, style: Theme.of(context).textTheme.titleSmall,),
+
+          ],
         ),
         actions: [
           TextButton(

--- a/lib/services/project_manager_service.dart
+++ b/lib/services/project_manager_service.dart
@@ -30,4 +30,6 @@ class ProjectManagerService extends ChangeNotifier {
     _filePath = null;
     notifyListeners();
   }
+
+
 }

--- a/lib/util/anomaly_helpers.dart
+++ b/lib/util/anomaly_helpers.dart
@@ -1,0 +1,15 @@
+import 'package:skavl/entity/anomaly_set.dart';
+
+/// Merges [incoming] anomaly sets into [existing] replacing existing entries that share imageName.
+///
+/// Used when continuing analysis to not overwrite entire analysis.
+List<AnomalySet> mergeAnomalySets(
+    List<AnomalySet> existing,
+    List<AnomalySet> incoming,
+    ) {
+  final incomingNames = incoming.map((s) => s.imageName).toSet();
+  return [
+    ...existing.where((s) => !incomingNames.contains(s.imageName)),
+    ...incoming,
+  ];
+}

--- a/service-versions.json
+++ b/service-versions.json
@@ -1,5 +1,5 @@
 {
   "tiler": "v0.2.0-pre",
-  "skavl_anomaly": "v0.3.1-pre",
+  "skavl_anomaly": "v0.3.2-pre",
   "skavl_report": "v0.2.2-pre"
 }


### PR DESCRIPTION
Updated to handle continuation of analysis. Implements Anomaly Service PR: https://github.com/NTNUFrokostklubben/anomaly-detection-module/pull/145

Default logic for running analysis now continues a previous analysis.
Restart analysis is hidden under a 3-dot menu in the project overview page as this is a destructive action.